### PR TITLE
APF-696: Fix AWS cert error handling

### DIFF
--- a/common/core/src/main/java/com/vmware/connectors/common/web/ObservableUtil.java
+++ b/common/core/src/main/java/com/vmware/connectors/common/web/ObservableUtil.java
@@ -8,6 +8,7 @@ package com.vmware.connectors.common.web;
 import org.springframework.web.client.HttpClientErrorException;
 import rx.Observable;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 public final class ObservableUtil {
@@ -23,6 +24,17 @@ public final class ObservableUtil {
             return Observable.empty();
         } else {
             // If the problem is not 404, let the problem bubble up
+            return Observable.error(throwable);
+        }
+    }
+
+    public static <R> Observable<R> skip400(Throwable throwable) {
+        if (throwable instanceof HttpClientErrorException
+                && HttpClientErrorException.class.cast(throwable).getStatusCode() == BAD_REQUEST) {
+            // If it's OK to let bad requests be skipped, proceed; we just won't create a card.
+            return Observable.empty();
+        } else {
+            // If the problem is not 400, let the problem bubble up
             return Observable.error(throwable);
         }
     }

--- a/connectors/aws-cert/src/main/java/com/vmware/connectors/aws/cert/AwsCertController.java
+++ b/connectors/aws-cert/src/main/java/com/vmware/connectors/aws/cert/AwsCertController.java
@@ -15,6 +15,7 @@ import com.vmware.connectors.common.payloads.response.CardBodyFieldType;
 import com.vmware.connectors.common.payloads.response.Cards;
 import com.vmware.connectors.common.utils.Async;
 import com.vmware.connectors.common.utils.CardTextAccessor;
+import com.vmware.connectors.common.web.ObservableUtil;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -151,10 +152,10 @@ public class AwsCertController {
     private Observable<Pair<String, ResponseEntity<String>>> getAllCardsInfo(Set<String> approvalUrls) {
         return Observable
                 .from(approvalUrls)
-                .flatMapSingle(this::callForCardInfo);
+                .flatMap(this::callForCardInfo);
     }
 
-    private Single<Pair<String, ResponseEntity<String>>> callForCardInfo(String approvalUrl) {
+    private Observable<Pair<String, ResponseEntity<String>>> callForCardInfo(String approvalUrl) {
         logger.trace("callForCardInfo called: approvalUrl={}", approvalUrl);
 
         ListenableFuture<ResponseEntity<String>> response = rest.exchange(
@@ -168,6 +169,10 @@ public class AwsCertController {
         );
 
         return Async.toSingle(response)
+                .toObservable()
+                // Don't let a bad AWS token skip the rest
+                .onErrorResumeNext(ObservableUtil::skip400) // Expired requests will return 400 bad request
+                .onErrorResumeNext(ObservableUtil::skip404) // Non-existent contexts will return 404 not found
                 .map(responseEntity -> Pair.of(approvalUrl, responseEntity));
     }
 

--- a/connectors/aws-cert/src/test/java/com/vmware/connectors/aws/cert/AwsCertControllerTests.java
+++ b/connectors/aws-cert/src/test/java/com/vmware/connectors/aws/cert/AwsCertControllerTests.java
@@ -5,7 +5,6 @@
 
 package com.vmware.connectors.aws.cert;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.vmware.connectors.test.ControllerTestsBase;
 import com.vmware.connectors.test.JsonReplacementsBuilder;
@@ -15,24 +14,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.match.MockRestRequestMatchers;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.AsyncRestTemplate;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import static org.springframework.http.HttpHeaders.ACCEPT_LANGUAGE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_HTML;
@@ -46,12 +39,6 @@ public class AwsCertControllerTests extends ControllerTestsBase {
 
     @Autowired
     private AsyncRestTemplate rest;
-
-    @Autowired
-    private ObjectMapper mapper;
-
-    @Autowired
-    private MockMvc mockMvc;
 
     private MockRestServiceServer mockAws;
 
@@ -143,6 +130,62 @@ public class AwsCertControllerTests extends ControllerTestsBase {
                         content().string(
                                 JsonReplacementsBuilder
                                         .from(fromFile("/awscert/responses/success/cards/card.json"))
+                                        .buildForCards()
+                        )
+                );
+
+        mockAws.verify();
+    }
+
+    @Test
+    public void testRequestCards404DoesNotError() throws Exception {
+        mockAws.expect(requestTo("https://test-aws-region-1.certificates.fake-amazon.com/approvals?code=test-auth-code-1&context=test-context-1"))
+                .andExpect(method(GET))
+                .andRespond(withStatus(NOT_FOUND));
+
+        mockAws.expect(requestTo("https://test-aws-region-2.certificates.fake-amazon.com/approvals?code=test-auth-code-2&context=test-context-2"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(fromFile("awscert/fake/approval-page-2.html"), TEXT_HTML));
+
+        mockAws.expect(requestTo("https://certificates.FAKE-amazon.com/approvals?code=test-auth-code-3&context=test-context-3"))
+                .andExpect(method(GET))
+                .andRespond(withStatus(NOT_FOUND));
+
+        requestCards("valid/cards/card.json")
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(
+                        content().string(
+                                JsonReplacementsBuilder
+                                        .from(fromFile("/awscert/responses/success/cards/single-card.json"))
+                                        .buildForCards()
+                        )
+                );
+
+        mockAws.verify();
+    }
+
+    @Test
+    public void testRequestCards400DoesNotError() throws Exception {
+        mockAws.expect(requestTo("https://test-aws-region-1.certificates.fake-amazon.com/approvals?code=test-auth-code-1&context=test-context-1"))
+                .andExpect(method(GET))
+                .andRespond(withBadRequest());
+
+        mockAws.expect(requestTo("https://test-aws-region-2.certificates.fake-amazon.com/approvals?code=test-auth-code-2&context=test-context-2"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(fromFile("awscert/fake/approval-page-2.html"), TEXT_HTML));
+
+        mockAws.expect(requestTo("https://certificates.FAKE-amazon.com/approvals?code=test-auth-code-3&context=test-context-3"))
+                .andExpect(method(GET))
+                .andRespond(withBadRequest());
+
+        requestCards("valid/cards/card.json")
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(
+                        content().string(
+                                JsonReplacementsBuilder
+                                        .from(fromFile("/awscert/responses/success/cards/single-card.json"))
                                         .buildForCards()
                         )
                 );

--- a/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/single-card.json
+++ b/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/single-card.json
@@ -1,0 +1,63 @@
+{
+  "cards": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "name": "AwsCert",
+      "creation_date": "1970-01-01T00:00:00Z",
+      "expiration_date": "1970-01-01T00:00:00Z",
+      "template": {
+        "href": "https://hero/connectors/aws-cert/templates/generic.hbs"
+      },
+      "header": {
+        "title": "AWS Cert Req For test-subdomain-2.acme.com",
+        "subtitle": "AWS Certificate Request"
+      },
+      "body": {
+        "description": "Review the information presented below and click I Approve only if you recognize the request and the account requesting it.  By clicking I Approve, you authorize Amazon to request a certificate for the above domain name.",
+        "fields": [
+          {
+            "type": "GENERAL",
+            "title": "Domain name",
+            "description": "test-subdomain-2.acme.com"
+          },
+          {
+            "type": "GENERAL",
+            "title": "AWS account number",
+            "description": "test-aws-account-number-2"
+          },
+          {
+            "type": "GENERAL",
+            "title": "AWS Region",
+            "description": "test-aws-region-2"
+          },
+          {
+            "type": "GENERAL",
+            "title": "Certificate identifier",
+            "description": "test-certificate-id-2"
+          }
+        ]
+      },
+      "actions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "label": "Approve",
+          "url": {
+            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+          },
+          "type": "POST",
+          "action_key": "DIRECT",
+          "request": {
+            "validation_token": "test-validation-token-2",
+            "utf8": "\u2713",
+            "context": "test-context-2",
+            "commit": "I Approve",
+            "authenticity_token": "test-csrf-token-2",
+            "hero_aws_cert_approval_url": "https://test-aws-region-2.certificates.fake-amazon.com/approvals?code=test-auth-code-2&context=test-context-2"
+          },
+          "user_input": [],
+          "completed_label": "Approved"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes error handling by skipping 404 not found and 400 bad requests when
fetching approval pages.  404 not found is returned when the context param
isn't found.  400 bad request is returned when the approval request is expired.
In both cases, we shouldn't error and instead should filter out the failures
and return the cards that succeeded.

Signed-off-by: John Bard <jbard@vmware.com>