### PR TITLE
APF-711 Add check for RPM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,10 +56,9 @@ Vagrant.configure("2") do |config|
 
      # Customize the amount of memory on the VM:
      vb.memory = "8192"
-   end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
+  end
+
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
@@ -67,5 +66,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     yum update -y
     yum install -y git rpm-build vim nmap-ncat java-1.8.0-openjdk-devel
+    curl -fsSL get.docker.com -o get-docker.sh
+    sh get-docker.sh
+    usermod -aG docker vagrant
+    service docker start
   SHELL
 end

--- a/connectors/airwatch/pom.xml
+++ b/connectors/airwatch/pom.xml
@@ -89,6 +89,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/airwatch/src/test/resources/application.properties
+++ b/connectors/airwatch/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem

--- a/connectors/aws-cert/pom.xml
+++ b/connectors/aws-cert/pom.xml
@@ -99,6 +99,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/aws-cert/src/test/resources/application.properties
+++ b/connectors/aws-cert/src/test/resources/application.properties
@@ -1,3 +1,2 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem
 aws.certificate.connector.approval.host=certificates.Fake-Amazon.com
 aws.certificate.connector.approval.path=/approvals

--- a/connectors/concur/pom.xml
+++ b/connectors/concur/pom.xml
@@ -87,6 +87,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/concur/src/test/resources/application.properties
+++ b/connectors/concur/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem

--- a/connectors/github-pr/pom.xml
+++ b/connectors/github-pr/pom.xml
@@ -93,6 +93,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/github-pr/src/test/resources/application.properties
+++ b/connectors/github-pr/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem

--- a/connectors/jira/pom.xml
+++ b/connectors/jira/pom.xml
@@ -80,6 +80,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/jira/src/test/resources/application.properties
+++ b/connectors/jira/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem

--- a/connectors/salesforce/pom.xml
+++ b/connectors/salesforce/pom.xml
@@ -84,6 +84,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/salesforce/src/test/resources/application.properties
+++ b/connectors/salesforce/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem

--- a/connectors/servicenow/pom.xml
+++ b/connectors/servicenow/pom.xml
@@ -93,6 +93,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/servicenow/src/test/resources/application.properties
+++ b/connectors/servicenow/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem

--- a/connectors/socialcast/pom.xml
+++ b/connectors/socialcast/pom.xml
@@ -88,6 +88,17 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>check-rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/connectors/socialcast/src/test/resources/application.properties
+++ b/connectors/socialcast/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-security.oauth2.resource.jwt.key-uri=https://acme.vmwareidentity.com/SAAS/API/1.0/REST/auth/token?attribute=publicKey&format=pem

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,71 @@
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.23.0</version>
+                    <configuration>
+                        <images>
+                            <image>
+                                <name>connector</name>
+                                <build>
+                                    <from>centos/systemd:latest</from>
+                                    <assembly>
+                                        <inline>
+                                            <id>rpm</id>
+                                            <fileSets>
+                                                <fileSet>
+                                                    <includes>
+                                                        <include>target/**/*.rpm</include>
+                                                    </includes>
+                                                </fileSet>
+                                            </fileSets>
+                                        </inline>
+                                    </assembly>
+                                    <runCmds>
+                                        <run>yum -y install /maven/target/rpm/${connector.name}-connector/RPMS/noarch/*.rpm</run>
+                                        <run>
+                                            <![CDATA[
+                                                echo "security.oauth2.resource.jwt.key-value=foo" \
+                                                > /etc/opt/vmware/connectors/${connector.name}/application.properties
+                                                ]]>
+                                        </run>
+                                    </runCmds>
+                                    <cmd>
+                                        <shell>/usr/sbin/init</shell>
+                                    </cmd>
+                                </build>
+                                <run>
+                                    <privileged>true</privileged>
+                                    <ports>connector.port:8080</ports>
+                                    <wait>
+                                        <!-- Build will fail if not healthy within 60 seconds -->
+                                        <time>60000</time>
+                                        <http>
+                                            <url>http://localhost:${connector.port}/health</url>
+                                            <method>GET</method>
+                                            <status>200</status>
+                                        </http>
+                                    </wait>
+                                </run>
+                            </image>
+                        </images>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>build</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>build</goal>
+                                <goal>start</goal>
+                                <goal>stop</goal>
+                                <goal>remove</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
This change adds a check to ensure that the connectors can be installed
using the generated RPMs.

As part of the build (when the check-rpm profile is active) we now spin
up a Centos 7 Docker container and install and configure the connector.
If the connector's health check doesn't succeed within 60s, the build will fail.