### PR TITLE
APF-715: Fix NcssCount in SalesforceController

### DIFF
--- a/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SFAccount.java
+++ b/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SFAccount.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2018 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package com.vmware.connectors.salesforce;
+
+import com.google.common.collect.ImmutableList;
+import org.pojomatic.Pojomatic;
+import org.pojomatic.annotations.AutoProperty;
+
+import java.util.List;
+
+/**
+ * This class is a Memento encapsulating the things we need to know about a Salesforce account.
+ * Instances of this class are immutable.
+ */
+@AutoProperty
+public class SFAccount {
+
+    private final String id;
+    private final String name;
+    private final List<SFOpportunity> opportunities;
+
+    SFAccount(String id, String name) {
+        this.id = id;
+        this.name = name;
+        this.opportunities = ImmutableList.of();
+    }
+
+    SFAccount(SFAccount account, List<SFOpportunity> opportunities) {
+        this.id = account.getId();
+        this.name = account.getName();
+        this.opportunities = ImmutableList.copyOf(opportunities);
+    }
+
+    String getId() {
+        return id;
+    }
+
+    String getName() {
+        return name;
+    }
+
+    /**
+     * Returns an immutable list of salesforce account's opportunities.
+     */
+    List<SFOpportunity> getAccOpportunities() {
+        return opportunities;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Pojomatic.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Pojomatic.hashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return Pojomatic.toString(this);
+    }
+
+}

--- a/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SFOpportunity.java
+++ b/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SFOpportunity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2018 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package com.vmware.connectors.salesforce;
+
+import org.pojomatic.Pojomatic;
+import org.pojomatic.annotations.AutoProperty;
+
+/**
+ * Instances of this class are immutable.
+ */
+@AutoProperty
+public class SFOpportunity {
+
+    private final String id;
+    private final String name;
+
+    SFOpportunity(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    String getId() {
+        return id;
+    }
+
+    String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return Pojomatic.equals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Pojomatic.hashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return Pojomatic.toString(this);
+    }
+
+}

--- a/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SalesforceController.java
+++ b/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SalesforceController.java
@@ -5,6 +5,8 @@
 
 package com.vmware.connectors.salesforce;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.vmware.connectors.common.json.JsonDocument;
@@ -16,26 +18,24 @@ import com.vmware.connectors.common.payloads.response.*;
 import com.vmware.connectors.common.utils.Async;
 import com.vmware.connectors.common.utils.CardTextAccessor;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.pojomatic.Pojomatic;
-import org.pojomatic.annotations.AutoProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.util.Base64Utils;
-import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.AsyncRestOperations;
-import org.springframework.web.util.UriComponentsBuilder;
 import rx.Observable;
 import rx.Single;
 
 import javax.validation.Valid;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -45,16 +45,16 @@ import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
 
 @RestController
 public class SalesforceController {
-    private final static Logger logger = LoggerFactory.getLogger(SalesforceController.class);
-    private final static String SALESFORCE_AUTH_HEADER = "x-salesforce-authorization";
-    private final static String SALESFORCE_BASE_URL_HEADER = "x-salesforce-base-url";
-    private final static String ROUTING_PREFIX = "x-routing-prefix";
+
+    private static final Logger logger = LoggerFactory.getLogger(SalesforceController.class);
+
+    private static final String SALESFORCE_AUTH_HEADER = "x-salesforce-authorization";
+    private static final String SALESFORCE_BASE_URL_HEADER = "x-salesforce-base-url";
+    private static final String ROUTING_PREFIX = "x-routing-prefix";
     private static final String ADD_CONVERSATIONS_PATH = "/conversations";
     private static final String CONVERSATION_TYPE = "email";
 
-    private final static String WHITE_SPACE = " ";
-    private final static String NEW_LINE = "\n";
-    private final static int SIZE = 256;
+    // TODO: concatenating strings into a SOQL query like this may provide an avenue for a SOQL-injection attack
 
     // Get all Accounts owned by the user that have an existing Contact with the same domain as the sender's email
     //     but *not* those where the sender is already a Contact
@@ -63,13 +63,16 @@ public class SalesforceController {
     // We will have to eliminate duplicate Accounts and filter out those Accounts where the sender is already a Contact
     private static final String QUERY_FMT_ACCOUNT =
             "SELECT email, account.id, account.name FROM contact WHERE email LIKE '%%%s' AND account.owner.email = '%s'";
+
     // Query format to get contact details of email sender, from contact list owned by the user.
     private static final String QUERY_FMT_CONTACT =
             "SELECT name, account.name, MobilePhone FROM contact WHERE email = '%s' AND contact.owner.email = '%s'";
+
     // Query format to get list of all opportunity details that are related to the email sender.
     private static final String QUERY_FMT_CONTACT_OPPORTUNITY =
             "SELECT Opportunity.name, role, FORMAT(Opportunity.amount), Opportunity.probability from " +
                     "OpportunityContactRole WHERE contact.email='%s' AND opportunity.owner.email='%s'";
+
     // Query format to get list of all opportunities that are related to an account.
     private static final String QUERY_FMT_ACCOUNT_OPPORTUNITY =
             "SELECT id, name FROM opportunity WHERE account.id = '%s'";
@@ -96,12 +99,15 @@ public class SalesforceController {
     private final CardTextAccessor cardTextAccessor;
 
     @Autowired
-    public SalesforceController(AsyncRestOperations rest, CardTextAccessor cardTextAccessor,
-                                @Value("${sf.searchAccountsPath}") String sfSearchAccountPath,
-                                @Value("${sf.addContactPath}") String sfAddContactPath,
-                                @Value("${sf.opportunityContactLinkPath}") String sfOpportunityContactLinkPath,
-                                @Value("${sf.opportunityTaskLinkPath}") String sfOpportunityTaskLinkPath,
-                                @Value("${sf.attachmentTasklinkPath}") String sfAttachmentTasklinkPath) {
+    public SalesforceController(
+            AsyncRestOperations rest,
+            CardTextAccessor cardTextAccessor,
+            @Value("${sf.searchAccountsPath}") String sfSearchAccountPath,
+            @Value("${sf.addContactPath}") String sfAddContactPath,
+            @Value("${sf.opportunityContactLinkPath}") String sfOpportunityContactLinkPath,
+            @Value("${sf.opportunityTaskLinkPath}") String sfOpportunityTaskLinkPath,
+            @Value("${sf.attachmentTasklinkPath}") String sfAttachmentTasklinkPath
+    ) {
         this.rest = rest;
         this.cardTextAccessor = cardTextAccessor;
         this.sfSearchAccountPath = sfSearchAccountPath;
@@ -111,251 +117,280 @@ public class SalesforceController {
         this.sfAttachmentTasklinkPath = sfAttachmentTasklinkPath;
     }
 
-    @PostMapping(path = "/cards/requests", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    ///////////////////////////////////////////////////////////////////
+    // Methods common to both the cards request and the actions
+    ///////////////////////////////////////////////////////////////////
+
+    private HttpHeaders makeHeaders(String auth) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(AUTHORIZATION, auth);
+        return headers;
+    }
+
+    private HttpHeaders makeJsonHeaders(String auth) {
+        HttpHeaders headers = makeHeaders(auth);
+        headers.set(CONTENT_TYPE, APPLICATION_JSON_VALUE);
+        return headers;
+    }
+
+    /**
+     * Retrieve contact data from Salesforce.
+     *
+     * @param contactSoql - Specify the SOQL to run
+     */
+    private Single<ResponseEntity<JsonDocument>> retrieveContacts(
+            String auth,
+            String baseUrl,
+            String contactSoql
+    ) {
+        return Async.toSingle(
+                rest.exchange(
+                        makeSearchAccountUri(baseUrl, contactSoql),
+                        HttpMethod.GET,
+                        new HttpEntity<String>(makeHeaders(auth)),
+                        JsonDocument.class
+                )
+        );
+    }
+
+    private URI makeSearchAccountUri(
+            String baseUrl,
+            String soql
+    ) {
+        return fromHttpUrl(baseUrl)
+                .path(sfSearchAccountPath)
+                .queryParam("q", soql)
+                .build()
+                .toUri();
+    }
+
+    private URI makeUri(
+            String baseUrl,
+            String path
+    ) {
+        return fromHttpUrl(baseUrl)
+                .path(path)
+                .build()
+                .toUri();
+    }
+
+    ///////////////////////////////////////////////////////////////////
+    // Cards request methods
+    ///////////////////////////////////////////////////////////////////
+
+    @PostMapping(
+            path = "/cards/requests",
+            consumes = APPLICATION_JSON_VALUE,
+            produces = APPLICATION_JSON_VALUE
+    )
     public Single<ResponseEntity<Cards>> getCards(
-            @RequestHeader(name = SALESFORCE_AUTH_HEADER) String sfAuth,
-            @RequestHeader(name = SALESFORCE_BASE_URL_HEADER) String sfBaseUrl,
-            @RequestHeader(name = ROUTING_PREFIX) String routingPrefix,
-            @Valid @RequestBody CardRequest cardRequest) {
+            @RequestHeader(SALESFORCE_AUTH_HEADER) String auth,
+            @RequestHeader(SALESFORCE_BASE_URL_HEADER) String baseUrl,
+            @RequestHeader(ROUTING_PREFIX) String routingPrefix,
+            @Valid @RequestBody CardRequest cardRequest
+    ) {
         // Sender email and user email are required, and sender email has to at least have a non-final @ in it
-        final String senderEmail = cardRequest.getTokenSingleValue("sender_email");
-        final String userEmail = cardRequest.getTokenSingleValue("user_email");
-        logger.debug("Sender email: {} and User email: {} for Salesforce server: {} ", senderEmail, userEmail, sfBaseUrl);
-        final String senderDomain = '@' + StringUtils.substringAfterLast(senderEmail, "@");
+        String sender = cardRequest.getTokenSingleValue("sender_email");
+        String user = cardRequest.getTokenSingleValue("user_email");
+        logger.debug("Sender email: {} and User email: {} for Salesforce server: {} ", sender, user, baseUrl);
+        String senderDomain = '@' + StringUtils.substringAfterLast(sender, "@");
         // TODO: implement a better system of validating domain names than "yup, it's not empty"
-        if (StringUtils.isBlank(senderDomain) || StringUtils.isBlank(userEmail)) {
-            logger.warn("Either sender email or user email is blank for url: {}", sfBaseUrl);
+        if (StringUtils.isBlank(senderDomain) || StringUtils.isBlank(user)) {
+            logger.warn("Either sender email or user email is blank for url: {}", baseUrl);
             return Single.just(new ResponseEntity<>(BAD_REQUEST));
         }
 
-        // TODO: concatenating strings into a SOQL query like this may provide an avenue for a SOQL-injection attack
-        String contactDetailsSoql = String.format(QUERY_FMT_CONTACT, senderEmail, userEmail);
-        UriComponentsBuilder contactQueryUrlBuilder = fromHttpUrl(sfBaseUrl).path(sfSearchAccountPath).queryParam("q", contactDetailsSoql);
-        String opportunityDetailsSoql = String.format(QUERY_FMT_CONTACT_OPPORTUNITY, senderEmail, userEmail);
-        UriComponentsBuilder opportunityQueryUrlBuilder = fromHttpUrl(sfBaseUrl).path(sfSearchAccountPath).queryParam("q", opportunityDetailsSoql);
-        String accountDetailsSoql = String.format(QUERY_FMT_ACCOUNT, senderDomain, userEmail);
-        UriComponentsBuilder accountQueryUrlBuilder = fromHttpUrl(sfBaseUrl).path(sfSearchAccountPath).queryParam("q", accountDetailsSoql);
+        HttpHeaders headers = makeHeaders(auth);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, sfAuth);
-
-        ListenableFuture<ResponseEntity<JsonDocument>> contactsFuture =
-                rest.exchange(contactQueryUrlBuilder.build().toUri(),
-                        HttpMethod.GET, new HttpEntity<String>(headers), JsonDocument.class);
-        ListenableFuture<ResponseEntity<JsonDocument>> opportunitiesFuture =
-                rest.exchange(opportunityQueryUrlBuilder.build().toUri(),
-                        HttpMethod.GET, new HttpEntity<String>(headers), JsonDocument.class);
-        ListenableFuture<ResponseEntity<JsonDocument>> accountsFuture =
-                rest.exchange(accountQueryUrlBuilder.build().toUri(),
-                        HttpMethod.GET, new HttpEntity<String>(headers), JsonDocument.class);
-
-        return Async.toSingle(contactsFuture)
+        return retrieveContactInfos(auth, baseUrl, user, sender)
                 .map(HttpEntity::getBody)
-                .flatMap(contactDetails -> getCards(contactDetails, senderEmail, sfBaseUrl, routingPrefix, headers,
-                        opportunitiesFuture, accountsFuture))
+                .flatMap(contacts -> getCards(contacts, sender, baseUrl, routingPrefix, headers, user, senderDomain))
+                .map(cards -> {
+                    Cards c = new Cards();
+                    c.getCards().addAll(cards);
+                    return c;
+                })
                 .map(ResponseEntity::ok);
     }
 
-    private Single<Cards> getCards(JsonDocument contactDetails, String senderEmail, String sfBaseUrl, String routingPrefix, HttpHeaders headers,
-                                   ListenableFuture<ResponseEntity<JsonDocument>> opportunitiesFuture,
-                                   ListenableFuture<ResponseEntity<JsonDocument>> accountsFuture) {
+    // Retrieve contact name, account name, and phone
+    private Single<ResponseEntity<JsonDocument>> retrieveContactInfos(
+            String auth,
+            String baseUrl,
+            String userEmail,
+            String senderEmail
+    ) {
+        String contactSoql = String.format(QUERY_FMT_CONTACT, senderEmail, userEmail);
+
+        return retrieveContacts(auth, baseUrl, contactSoql);
+    }
+
+
+    private Single<List<Card>> getCards(
+            JsonDocument contactDetails,
+            String senderEmail,
+            String baseUrl,
+            String routingPrefix,
+            HttpHeaders headers,
+            String userEmail,
+            String senderDomain
+    ) {
         int contactsSize = contactDetails.read("$.totalSize");
         if (contactsSize > 0) {
             // Contact already exists in the salesforce account. Return a card to show the sender information.
             logger.debug("Returning contact info for email: {} ", senderEmail);
-            return Async.toSingle(opportunitiesFuture)
-                    .map(entity -> createUserDetailsCard(contactDetails, entity.getBody(), routingPrefix));
+            return makeCardFromContactDetails(headers, baseUrl, routingPrefix, userEmail, senderEmail, contactDetails)
+                    .map(ImmutableList::of);
         } else {
             // Contact doesn't exist in salesforce. Return a card to show accounts that are related to sender domain.
-            logger.debug("Returning accounts info for domain: {} ", StringUtils.substringAfterLast(senderEmail, "@"));
-            return Async.toSingle(accountsFuture)                                       // run the query
-                    .map(entity -> getUniqueAccounts(entity, senderEmail))              // filter the result
-                    .flatMap(list -> addRelatedOpportunities(list, sfBaseUrl, headers)) // fetch and add opp to each account.
-                    .map(list -> createRelatedAccountsCards(list, senderEmail, routingPrefix));        // convert into Cards
+            logger.debug("Returning accounts info for domain: {} ", senderDomain);
+            return makeCardsFromSenderDomain(headers, baseUrl, routingPrefix, userEmail, senderEmail, senderDomain);
         }
     }
 
-    @PostMapping(path = ADD_CONTACT_PATH, consumes = APPLICATION_FORM_URLENCODED_VALUE)
-    public Single<ResponseEntity<Void>> addContact(
-            @RequestHeader(name = SALESFORCE_AUTH_HEADER) String sfAuth,
-            @RequestHeader(name = SALESFORCE_BASE_URL_HEADER) String sfBaseUrl,
-            @PathVariable String accountId,
-            @RequestParam(name = "contact_email") String contactEmail,
-            @RequestParam(name = "first_name", required = false) String firstName,
-            @RequestParam(name = "last_name") String lastName,
-            @RequestParam(name = "opportunity_ids", required = false) Set<String> opportunityIds) {
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, sfAuth);
-        headers.set(CONTENT_TYPE, APPLICATION_JSON_VALUE);
-
-        final Map<String, String> bodyMap = new HashMap<>();
-        bodyMap.put("AccountId", accountId);
-        bodyMap.put("Email", contactEmail);
-        bodyMap.put("LastName", lastName);
-        if (StringUtils.isNotBlank(firstName)) {
-            bodyMap.put("FirstName", firstName);
-        }
-
-        logger.debug("Adding contact: {} with Salesforce server: {}", bodyMap, sfBaseUrl);
-
-        UriComponentsBuilder uriComponentsBuilder = fromHttpUrl(sfBaseUrl).path(sfAddContactPath);
-        ListenableFuture<ResponseEntity<JsonDocument>> future = rest.exchange(
-                uriComponentsBuilder.build().toUri(), HttpMethod.POST, new HttpEntity<>(bodyMap, headers), JsonDocument.class);
-        /*
-        Once we start using salesforce API version 34, following things can be done in a single network call.
-           - Create a new contact
-           - Link Opportunities to the contact (from 1-n).
-         More : https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_composite_sobject_tree_flat.htm
-         */
-        return Async.toSingle(future)
-                .flatMap(entity -> linkOpportunitiesToContact(entity, opportunityIds, sfBaseUrl, headers))
-                .map(entity -> ResponseEntity.status(entity.getStatusCode()).build());
+    private Single<Card> makeCardFromContactDetails(
+            HttpHeaders headers,
+            String baseUrl,
+            String routingPrefix,
+            String userEmail,
+            String senderEmail,
+            JsonDocument contactDetails
+    ) {
+        return retrieveOpportunities(headers, baseUrl, userEmail, senderEmail)
+                .map(entity -> createUserDetailsCard(contactDetails, entity.getBody(), routingPrefix));
     }
 
-    @PostMapping(path = ADD_CONVERSATIONS_PATH, consumes = APPLICATION_FORM_URLENCODED_VALUE)
-    public Single<ResponseEntity<Void>> addEmailConversation(
-            @RequestHeader(name = SALESFORCE_AUTH_HEADER) String sfAuth,
-            @RequestHeader(name = SALESFORCE_BASE_URL_HEADER) String sfBaseUrl,
-            @RequestParam("user_email") String userEmail,
-            @RequestParam("contact_email") String contactEmail,
-            @RequestParam("email_conversations") String conversations,
-            @RequestParam("attachment_name") String attachmentName,
-            @RequestParam("opportunity_ids") Set<String> opportunityIds) throws IOException {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, sfAuth);
-        byte[] formattedConversations = formatMessages(conversations).getBytes("UTF-8");
-        String contactIdSoql = String.format(QUERY_FMT_CONTACT_ID, contactEmail, userEmail);
-        UriComponentsBuilder contactQueryUrlBuilder = fromHttpUrl(sfBaseUrl).path(sfSearchAccountPath)
-                .queryParam("q", contactIdSoql);
-        ListenableFuture<ResponseEntity<JsonDocument>> contactsFuture = rest.exchange(
-                contactQueryUrlBuilder.build().toUri(), HttpMethod.GET,
-                new HttpEntity<String>(headers), JsonDocument.class);
-        return Async.toSingle(contactsFuture).flatMap(entity -> linkContactIdToOpportunity(
-                entity, opportunityIds,
-                formattedConversations, attachmentName,
-                sfBaseUrl, sfAuth)).map(entity ->
-                ResponseEntity.status(entity.getStatusCode()).build());
+    private Single<ResponseEntity<JsonDocument>> retrieveOpportunities(
+            HttpHeaders headers,
+            String baseUrl,
+            String userEmail,
+            String senderEmail
+    ) {
+        String soql = String.format(QUERY_FMT_CONTACT_OPPORTUNITY, senderEmail, userEmail);
+
+        return Async.toSingle(
+                rest.exchange(
+                        makeSearchAccountUri(baseUrl, soql),
+                        HttpMethod.GET,
+                        new HttpEntity<String>(headers),
+                        JsonDocument.class
+                )
+        );
     }
 
-    private Single<ResponseEntity<Map<String, HttpStatus>>> linkContactIdToOpportunity(
-            ResponseEntity<JsonDocument> entity,
-            Set<String> opportunityIds,
-            byte[] conversations,
-            String attachmentName,
-            String sfBaseUrl, String sfAuth) {
-        List<String> contactId = entity.getBody().read("$..Id");
-        return Observable.from(opportunityIds)
-                .flatMap(opportunityId -> addEmailConversationToOpportunity(
-                        contactId.get(0),
-                        opportunityId,
-                        conversations,
-                        attachmentName,
-                        sfAuth,
-                        sfBaseUrl).toObservable())
-                .toMap(Pair::getRight, pair -> pair.getLeft().getStatusCode())
-                .map(ResponseEntity::ok)
-                .toSingle();
+    // Create card for showing information about the email sender, related opportunities.
+    private Card createUserDetailsCard(
+            JsonDocument contactDetails,
+            JsonDocument opportunityDetails,
+            String routingPrefix
+    ) {
+        String contactName = contactDetails.read("$.records[0].Name");
+        String contactPhNo = contactDetails.read("$.records[0].MobilePhone");
+        String contactAccountName = contactDetails.read("$.records[0].Account.Name");
+
+        CardBody.Builder cardBodyBuilder = new CardBody.Builder()
+                .setDescription(cardTextAccessor.getMessage("senderinfo.body"))
+                .addField(buildGeneralBodyField("senderinfo.name", contactName))
+                .addField(buildGeneralBodyField("senderinfo.account", contactAccountName))
+                .addField(buildGeneralBodyField("senderinfo.phone", contactPhNo));
+
+        addOpportunities(cardBodyBuilder, opportunityDetails);
+
+        return new Card.Builder()
+                .setName("Salesforce") // TODO - remove this in APF-536
+                .setTemplate(routingPrefix + "templates/generic.hbs")
+                .setHeader(cardTextAccessor.getMessage("senderinfo.header"), null)
+                .setBody(cardBodyBuilder.build())
+                .build();
     }
 
-    private Single<Pair<ResponseEntity<Void>, String>> addEmailConversationToOpportunity(
-            String contactId,
-            String opportunityId,
-            byte[] conversation,
-            String attachmentName,
-            String sfAuth,
-            String sfBaseUrl) {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, sfAuth);
-
-        final UriComponentsBuilder uriComponentsBuilder = fromHttpUrl(sfBaseUrl).path(sfOpportunityTaskLinkPath);
-        headers.set(AUTHORIZATION, sfAuth);
-        headers.set(CONTENT_TYPE, APPLICATION_JSON_VALUE);
-
-        final Map<String, String> bodyMap = new HashMap<>();
-        bodyMap.put("WhatId", opportunityId);
-        bodyMap.put("Subject", CONVERSATION_TYPE);
-        bodyMap.put("WhoId", contactId);
-        ListenableFuture<ResponseEntity<JsonDocument>> future = rest.exchange(
-                uriComponentsBuilder.build().toUri(), HttpMethod.POST,
-                new HttpEntity<>(bodyMap, headers), JsonDocument.class);
-        return Async.toSingle(future).flatMap(entity -> linkAttachmentToTask(
-                entity, conversation, attachmentName, sfBaseUrl, sfAuth)).
-                map(entity -> Pair.of(ResponseEntity.
-                        status(entity.getLeft().getStatusCode()).build(), opportunityId));
+    private CardBodyField buildGeneralBodyField(
+            String titleMessageKey,
+            String description
+    ) {
+        return new CardBodyField.Builder()
+                .setTitle(cardTextAccessor.getMessage(titleMessageKey))
+                .setType(CardBodyFieldType.GENERAL)
+                .setDescription(description)
+                .build();
     }
 
+    private void addOpportunities(
+            CardBody.Builder cardBodyBuilder,
+            JsonDocument opportunityDetails
+    ) {
+        // Fill in the opportunity details.
+        // Opportunity amount is an optional field in salesforce.
+        int totalOpportunities = opportunityDetails.read("$.totalSize");
 
-    private Single<Pair<ResponseEntity<Void>, String>> linkAttachmentToTask(
-            ResponseEntity<JsonDocument> entity,
-            byte[] conversations,
-            String attachmentName,
-            String sfBaseUrl,
-            String sfAuth) {
+        for (int oppIndex = 0; oppIndex < totalOpportunities; oppIndex++) {
 
-        final String parentId = entity.getBody().read("$.id");
+            String oppJsonPathPrefix = String.format("$.records[%d].", oppIndex);
 
-        final HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, sfAuth);
-        headers.set(CONTENT_TYPE, APPLICATION_JSON_VALUE);
+            String oppName = opportunityDetails.read(oppJsonPathPrefix + "Opportunity.Name");
+            String oppRole = opportunityDetails.read(oppJsonPathPrefix + "Role");
+            String oppProbability = Double.toString(
+                    opportunityDetails.read(oppJsonPathPrefix + "Opportunity.Probability")
+            ) + "%";
 
-        final Map<String, String> bodyMap = new HashMap<>();
-        bodyMap.put("Body", Base64Utils.encodeToString(conversations));
-        bodyMap.put("ParentId", parentId);
-        bodyMap.put("Name", attachmentName);
-        bodyMap.put("ContentType", TEXT_PLAIN_VALUE);
+            cardBodyBuilder
+                    .addField(buildGeneralBodyField("senderinfo.opportunity.title", oppName))
+                    .addField(buildGeneralBodyField("senderinfo.opportunity.role", oppRole))
+                    .addField(buildGeneralBodyField("senderinfo.opportunity.probability", oppProbability));
 
-        final UriComponentsBuilder uriComponentsBuilder = fromHttpUrl(sfBaseUrl).path(sfAttachmentTasklinkPath);
-        final ListenableFuture<ResponseEntity<JsonDocument>> future = rest.exchange(
-                uriComponentsBuilder.build().toUri(), HttpMethod.POST,
-                new HttpEntity<>(bodyMap, headers), JsonDocument.class);
-        return Async.toSingle(future).map(attachmentEntity ->
-                Pair.of(ResponseEntity.status(attachmentEntity.
-                        getStatusCode()).build(), parentId));
-    }
+            String oppAmount = opportunityDetails.read(oppJsonPathPrefix + "Opportunity.Amount");
 
-    // Link each opportunity to the contact.
-    private Single<ResponseEntity<Map<String, HttpStatus>>> linkOpportunitiesToContact(ResponseEntity<JsonDocument> addContactResponse,
-                                                                                       Set<String> opportunityIds, String sfBaseUrl,
-                                                                                       HttpHeaders headers) {
-        if (null == opportunityIds) {
-            // No opportunity is available to link
-            return Single.just(ResponseEntity.status(addContactResponse.getStatusCode()).build());
-        } else {
-            String contactId = addContactResponse.getBody().read("$.id");
-
-            return Observable.from(opportunityIds)
-                    .flatMap(oppId -> oppToContact(sfBaseUrl, headers, oppId, contactId).toObservable())
-                    .toMap(Pair::getRight, pair -> pair.getLeft().getStatusCode())
-                    .map(ResponseEntity::ok)
-                    .toSingle();
+            if (StringUtils.isNotBlank(oppAmount)) {
+                cardBodyBuilder.addField(buildGeneralBodyField("senderinfo.opportunity.amount", oppAmount));
+            }
         }
     }
 
-    private Single<Pair<ResponseEntity<Void>, String>> oppToContact(final String sfBaseUrl,
-                                                                    final HttpHeaders headers,
-                                                                    final String oppId,
-                                                                    final String contactId) {
-        final Map<String, String> bodyMap = new HashMap<>();
-        bodyMap.put("OpportunityId", oppId);
-        bodyMap.put("ContactId", contactId);
-
-        final UriComponentsBuilder uriComponentsBuilder = fromHttpUrl(sfBaseUrl).path(sfOpportunityContactLinkPath);
-        final ListenableFuture<ResponseEntity<String>> oppLinkFuture = rest.exchange(
-                uriComponentsBuilder.build().toUri(), HttpMethod.POST, new HttpEntity<>(bodyMap, headers), String.class);
-        return Async.toSingle(oppLinkFuture)
-                .map(entity -> Pair.of(ResponseEntity.status(entity.getStatusCode()).build(), oppId));
+    private Single<List<Card>> makeCardsFromSenderDomain(
+            HttpHeaders headers,
+            String baseUrl,
+            String routingPrefix,
+            String userEmail,
+            String senderEmail,
+            String senderDomain
+    ) {
+        return retrieveAccountDetails(headers, baseUrl, userEmail, senderDomain)
+                .map(ResponseEntity::getBody)
+                .map(body -> body.<List<Map<String, Object>>>read("$.records"))
+                .map(contactRecords -> getUniqueAccounts(contactRecords, senderEmail))
+                .flatMap(accounts -> addRelatedOpportunities(accounts, baseUrl, headers))
+                .map(list -> createRelatedAccountsCards(list, senderEmail, routingPrefix));
     }
 
-    // Convert the JSON response into a Set of unique Accounts, *excluding* those Accounts that
-    // already have the email sender as a Contact
-    private List<SFAccount> getUniqueAccounts(ResponseEntity<JsonDocument> result, String senderEmail) {
+    private Single<ResponseEntity<JsonDocument>> retrieveAccountDetails(
+            HttpHeaders headers,
+            String baseUrl,
+            String userEmail,
+            String senderDomain
+    ) {
+        String soql = String.format(QUERY_FMT_ACCOUNT, senderDomain, userEmail);
 
+        return Async.toSingle(
+                rest.exchange(
+                        makeSearchAccountUri(baseUrl, soql),
+                        HttpMethod.GET,
+                        new HttpEntity<String>(headers),
+                        JsonDocument.class
+                )
+        );
+    }
+
+    /**
+     * Convert into a Set of unique Accounts, *excluding* those Accounts that
+     * already have the email sender as a Contact.
+     */
+    private List<SFAccount> getUniqueAccounts(
+            List<Map<String, Object>> contactRecords,
+            String senderEmail
+    ) {
         // We use these Sets to filter out duplicate entries
         Set<SFAccount> uniqueAccounts = new HashSet<>();
         Set<SFAccount> accountsWithExistingContact = new HashSet<>();
-
-        List<Map<String, Object>> contactRecords = result.getBody().read("$.records");
 
         for (Map<String, Object> acctRecord : contactRecords) {
             // Get a reusable context for JsonPath parsing
@@ -384,281 +419,409 @@ public class SalesforceController {
         return new ArrayList<>(uniqueAccounts);
     }
 
-    private Single<List<SFAccount>> addRelatedOpportunities(List<SFAccount> uniqueAccounts, String sfBaseUrl,
-                                                            HttpHeaders headers) {
+    private Single<List<SFAccount>> addRelatedOpportunities(
+            List<SFAccount> uniqueAccounts,
+            String baseUrl,
+            HttpHeaders headers
+    ) {
         // Fetch list of opportunities related to each account. Update the account objects with the result.
-        return Observable.from(uniqueAccounts)
-                .flatMap(sfAccount -> setAccOpportunities(sfAccount, sfBaseUrl, headers).toObservable())
+        return Observable
+                .from(uniqueAccounts)
+                .flatMapSingle(account -> supplementAccOpportunities(account, baseUrl, headers))
                 .toList()
                 .toSingle();
     }
 
-    private Single<SFAccount> setAccOpportunities(SFAccount sfAccount, String sfBaseUrl, HttpHeaders headers) {
-        String accOppSoql = String.format(QUERY_FMT_ACCOUNT_OPPORTUNITY, sfAccount.getId());
-        UriComponentsBuilder accOppQueryUrlBuilder = fromHttpUrl(sfBaseUrl).path(sfSearchAccountPath).queryParam("q", accOppSoql);
-        ListenableFuture<ResponseEntity<JsonDocument>> accOppFuture =
-                rest.exchange(accOppQueryUrlBuilder.build().toUri(),
-                        HttpMethod.GET, new HttpEntity<String>(headers), JsonDocument.class);
-
-        return Async.toSingle(accOppFuture)
-                .map(entity -> setAccOpportunities(entity.getBody(), sfAccount));
+    private Single<SFAccount> supplementAccOpportunities(
+            SFAccount account,
+            String baseUrl,
+            HttpHeaders headers
+    ) {
+        return retrieveAccountOpportunities(headers, baseUrl, account.getId())
+                .map(entity -> setAccOpportunities(entity.getBody(), account));
     }
 
-    private SFAccount setAccOpportunities(JsonDocument accOpportunityResponse, SFAccount sfAccount) {
-        List<SFOpportunity> accRelatedOpportunities = new ArrayList<>();
-        List<Object> oppObjects = accOpportunityResponse.read("$.records");
-        for (Object oppObject : oppObjects) {
-            DocumentContext ctx = JsonPath.parse(oppObject);
-            String id = ctx.read("$.Id");
-            String name = ctx.read("$.Name");
-            SFOpportunity sfOpportunity = new SFOpportunity(id, name);
-            accRelatedOpportunities.add(sfOpportunity);
-        }
-        sfAccount.setAccOpportunities(accRelatedOpportunities);
-        return sfAccount;
+    private  Single<ResponseEntity<JsonDocument>> retrieveAccountOpportunities(
+            HttpHeaders headers,
+            String baseUrl,
+            String accountId
+    ) {
+        String soql = String.format(QUERY_FMT_ACCOUNT_OPPORTUNITY, accountId);
+
+        return Async.toSingle(
+                rest.exchange(
+                        makeSearchAccountUri(baseUrl, soql),
+                        HttpMethod.GET,
+                        new HttpEntity<String>(headers),
+                        JsonDocument.class
+                )
+        );
     }
 
-
-    // Create card for showing information about the email sender, related opportunities.
-    private Cards createUserDetailsCard(JsonDocument contactDetails, JsonDocument opportunityDetails, String routingPrefix) {
-        Cards cards = new Cards();
-        String contactName = contactDetails.read("$.records[0].Name");
-        String contactPhNo = contactDetails.read("$.records[0].MobilePhone");
-        String contactAccountName = contactDetails.read("$.records[0].Account.Name");
-
-        CardBody.Builder cardBodyBuilder = new CardBody.Builder()
-                .setDescription(cardTextAccessor.getMessage("senderinfo.body"));
-
-        CardBodyField.Builder cardFieldBuilder = new CardBodyField.Builder()
-                .setTitle(cardTextAccessor.getMessage("senderinfo.name"))
-                .setDescription(contactName)
-                .setType(CardBodyFieldType.GENERAL);
-        cardBodyBuilder.addField(cardFieldBuilder.build());
-
-        cardFieldBuilder
-                .setTitle(cardTextAccessor.getMessage("senderinfo.account"))
-                .setDescription(contactAccountName)
-                .setType(CardBodyFieldType.GENERAL);
-        cardBodyBuilder.addField(cardFieldBuilder.build());
-
-        cardFieldBuilder
-                .setTitle(cardTextAccessor.getMessage("senderinfo.phone"))
-                .setDescription(contactPhNo)
-                .setType(CardBodyFieldType.GENERAL);
-        cardBodyBuilder.addField(cardFieldBuilder.build());
-
-        // Fill in the opportunity details.
-        // Opportunity amount is an optional field in salesforce.
-        int totalOpportunities = opportunityDetails.read("$.totalSize");
-        for (int oppIndex = 0; oppIndex < totalOpportunities; oppIndex++) {
-            String oppName = opportunityDetails.read(String.format("$.records[%d].Opportunity.Name", oppIndex));
-            String oppRole = opportunityDetails.read(String.format("$.records[%d].Role", oppIndex));
-            String oppProbability = Double.toString(opportunityDetails
-                    .read(String.format("$.records[%d].Opportunity.Probability", oppIndex))).concat("%");
-            String oppAmount = opportunityDetails.read(String.format("$.records[%d].Opportunity.Amount", oppIndex));
-            cardFieldBuilder
-                    .setTitle(cardTextAccessor.getMessage("senderinfo.opportunity.title"))
-                    .setDescription(oppName)
-                    .setType(CardBodyFieldType.GENERAL);
-            cardBodyBuilder.addField(cardFieldBuilder.build());
-            cardFieldBuilder
-                    .setTitle(cardTextAccessor.getMessage("senderinfo.opportunity.role"))
-                    .setDescription(oppRole)
-                    .setType(CardBodyFieldType.GENERAL);
-            cardBodyBuilder.addField(cardFieldBuilder.build());
-            cardFieldBuilder
-                    .setTitle(cardTextAccessor.getMessage("senderinfo.opportunity.probability"))
-                    .setDescription(oppProbability)
-                    .setType(CardBodyFieldType.GENERAL);
-            cardBodyBuilder.addField(cardFieldBuilder.build());
-            if (StringUtils.isNotBlank(oppAmount)) {
-                cardFieldBuilder
-                        .setTitle(cardTextAccessor.getMessage("senderinfo.opportunity.amount"))
-                        .setDescription(oppAmount)
-                        .setType(CardBodyFieldType.GENERAL);
-                cardBodyBuilder.addField(cardFieldBuilder.build());
-            }
-        }
-
-        Card.Builder cardBuilder = new Card.Builder()
-                .setName("Salesforce")
-                .setTemplate(routingPrefix + "templates/generic.hbs")
-                .setHeader(cardTextAccessor.getMessage("senderinfo.header"), null)
-                .setBody(cardBodyBuilder.build());
-
-        cards.getCards().add(cardBuilder.build());
-        return cards;
+    private SFAccount setAccOpportunities(
+            JsonDocument accOpportunityResponse,
+            SFAccount account
+    ) {
+        return new SFAccount(
+                account,
+                accOpportunityResponse.<List<Object>>read("$.records")
+                        .stream()
+                        .map(JsonPath::parse)
+                        .map(ctx -> new SFOpportunity(ctx.read("$.Id"), ctx.read("$.Name")))
+                        .collect(Collectors.toList())
+        );
     }
+
 
     // Create a Card for each unique account, account related opportunities
-    private Cards createRelatedAccountsCards(List<SFAccount> accounts, String contactEmail, String routingPrefix) {
-        Cards cards = new Cards();
-
-        for (SFAccount acct : accounts) {
-
-            String acctId = acct.getId();
-            String accountName = acct.getName();
-            List<SFOpportunity> opportunities = acct.getAccOpportunities();
-            String addContactLink = routingPrefix + ADD_CONTACT_PATH.replace("{accountId}", acctId);
-
-            CardAction.Builder actionBuilder = new CardAction.Builder()
-                    .setLabel(cardTextAccessor.getActionLabel("addcontact.add"))
-                    .setCompletedLabel(cardTextAccessor.getActionCompletedLabel("addcontact.add"))
-                    .setActionKey("USER_INPUT")
-                    .setUrl(addContactLink)
-                    .setType(HttpMethod.POST)
-                    .addRequestParam("contact_email", contactEmail);
-
-            CardActionInputField.Builder inputFieldBuilder = new CardActionInputField.Builder();
-
-            inputFieldBuilder.setId("first_name")
-                    .setLabel("First name")
-                    .setMinLength(1);
-            actionBuilder.addUserInputField(inputFieldBuilder.build());
-
-            inputFieldBuilder.setId("last_name")
-                    .setLabel("Last name")
-                    .setMinLength(1);
-            actionBuilder.addUserInputField(inputFieldBuilder.build());
-
-            if (!opportunities.isEmpty()) {  // There exists some opportunities related to this account.
-                inputFieldBuilder.setId("opportunity_ids")
-                        .setLabel(cardTextAccessor.getMessage("account.opportunity.label"))
-                        .setFormat("select")
-                        .setMinLength(0);
-                for (SFOpportunity sfOpportunity : opportunities) {
-                    inputFieldBuilder.addOption(sfOpportunity.getId(), sfOpportunity.getName());
-                }
-                actionBuilder.addUserInputField(inputFieldBuilder.build());
-            }
-
-            Card.Builder cardBuilder = new Card.Builder()
-                    .setName("Salesforce")
-                    .setTemplate(routingPrefix + "templates/generic.hbs")
-                    .setHeader(cardTextAccessor.getMessage("addcontact.header"), null)
-                    .setBody(cardTextAccessor.getMessage("addcontact.body", contactEmail, accountName))
-                    .addAction(actionBuilder.build());
-
-            cards.getCards().add(cardBuilder.build());
-        }
-        return cards;
+    private List<Card> createRelatedAccountsCards(
+            List<SFAccount> accounts,
+            String contactEmail,
+            String routingPrefix
+    ) {
+        return accounts
+                .stream()
+                .map(acct ->
+                        new Card.Builder()
+                                .setName("Salesforce")
+                                .setTemplate(routingPrefix + "templates/generic.hbs")
+                                .setHeader(cardTextAccessor.getMessage("addcontact.header"), null)
+                                .setBody(cardTextAccessor.getMessage("addcontact.body", contactEmail, acct.getName()))
+                                .addAction(createAddContactAction(routingPrefix, contactEmail, acct))
+                                .build()
+                )
+                .collect(Collectors.toList());
     }
 
-    private String formatMessages(String conversations) throws IOException {
-        MessageThread messageThread = MessageThread.parse(conversations);
-        List<Message> messageList = messageThread.getMessages();
-        StringBuilder messageBuilder = messageList.stream().map(this::formatSingleMessage)
-                .collect(StringBuilder::new, (container, element) ->
-                        container.append(element).append(NEW_LINE), StringBuilder::append);
-        return messageBuilder.toString();
+    private CardAction createAddContactAction(
+            String routingPrefix,
+            String contactEmail,
+            SFAccount acct
+    ) {
+        String acctId = acct.getId();
+        String addContactLink = routingPrefix + ADD_CONTACT_PATH.replace("{accountId}", acctId);
+
+        CardAction.Builder actionBuilder = new CardAction.Builder()
+                .setLabel(cardTextAccessor.getActionLabel("addcontact.add"))
+                .setCompletedLabel(cardTextAccessor.getActionCompletedLabel("addcontact.add"))
+                .setActionKey(CardActionKey.USER_INPUT)
+                .setUrl(addContactLink)
+                .setType(HttpMethod.POST)
+                .addRequestParam("contact_email", contactEmail)
+                .addUserInputField(
+                        new CardActionInputField.Builder()
+                                .setId("first_name")
+                                .setLabel("First name")
+                                .setMinLength(1)
+                                .build()
+                )
+                .addUserInputField(
+                        new CardActionInputField.Builder()
+                                .setId("last_name")
+                                .setLabel("Last name")
+                                .setMinLength(1).build()
+                );
+
+        addOpportunitiesSelectInputField(actionBuilder, acct.getAccOpportunities());
+
+        return actionBuilder.build();
+    }
+
+    private void addOpportunitiesSelectInputField(
+            CardAction.Builder actionBuilder,
+            List<SFOpportunity> opportunities
+    ) {
+        if (!opportunities.isEmpty()) {  // There exists some opportunities related to this account.
+            CardActionInputField.Builder inputFieldBuilder = new CardActionInputField.Builder()
+                    .setId("opportunity_ids")
+                    .setLabel(cardTextAccessor.getMessage("account.opportunity.label"))
+                    .setFormat("select")
+                    .setMinLength(0);
+            for (SFOpportunity sfOpportunity : opportunities) {
+                inputFieldBuilder.addOption(sfOpportunity.getId(), sfOpportunity.getName());
+            }
+            actionBuilder.addUserInputField(inputFieldBuilder.build());
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////
+    // Add Contact Action methods
+    ///////////////////////////////////////////////////////////////////
+
+    @PostMapping(
+            path = ADD_CONTACT_PATH,
+            consumes = APPLICATION_FORM_URLENCODED_VALUE
+    )
+    public Single<ResponseEntity<Void>> addContact(
+            @RequestHeader(SALESFORCE_AUTH_HEADER) String auth,
+            @RequestHeader(SALESFORCE_BASE_URL_HEADER) String baseUrl,
+            @PathVariable("accountId") String accountId,
+            @RequestParam("contact_email") String contactEmail,
+            @RequestParam(name = "first_name", required = false) String firstName,
+            @RequestParam("last_name") String lastName,
+            @RequestParam(name = "opportunity_ids", required = false) Set<String> opportunityIds
+    ) {
+        /*
+         * Once we start using salesforce API version 34, following things can be done in a single network call.
+         *  - Create a new contact
+         *  - Link Opportunities to the contact (from 1-n).
+         * More : https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_composite_sobject_tree_flat.htm
+         */
+        HttpHeaders headers = makeJsonHeaders(auth);
+
+        return addContact(headers, baseUrl, accountId, contactEmail, lastName, firstName)
+                .flatMap(entity -> linkOpportunitiesToContact(entity, opportunityIds, baseUrl, headers))
+                .map(entity -> ResponseEntity.status(entity.getStatusCode()).build());
+    }
+
+    private Single<ResponseEntity<JsonDocument>> addContact(
+            HttpHeaders headers,
+            String baseUrl,
+            String accountId,
+            String contactEmail,
+            String lastName,
+            String firstName
+    ) {
+        Map<String, String> body = new HashMap<>();
+
+        body.put("AccountId", accountId);
+        body.put("Email", contactEmail);
+        body.put("LastName", lastName);
+
+        if (StringUtils.isNotBlank(firstName)) {
+            body.put("FirstName", firstName);
+        }
+
+        logger.debug("Adding contact: {} with Salesforce server: {}", body, baseUrl);
+
+        return Async.toSingle(
+                rest.exchange(
+                        makeUri(baseUrl, sfAddContactPath),
+                        HttpMethod.POST,
+                        new HttpEntity<>(body, headers),
+                        JsonDocument.class
+                )
+            );
+    }
+
+    private Single<ResponseEntity<Void>> linkOpportunitiesToContact(
+            ResponseEntity<JsonDocument> addContactResponse,
+            Set<String> opportunityIds,
+            String baseUrl,
+            HttpHeaders headers
+    ) {
+        if (CollectionUtils.isEmpty(opportunityIds)) {
+            // No opportunity is available to link
+            return Single.just(ResponseEntity.status(addContactResponse.getStatusCode()).build());
+        } else {
+            String contactId = addContactResponse.getBody().read("$.id");
+
+            return Observable
+                    .from(opportunityIds)
+                    .flatMapSingle(opportunityId -> linkOpportunityToContact(baseUrl, headers, opportunityId, contactId))
+                    .map(ignored -> ResponseEntity.ok().<Void>build())
+                    .toSingle();
+        }
+    }
+
+    private Single<?> linkOpportunityToContact(
+            String baseUrl,
+            HttpHeaders headers,
+            String opportunityId,
+            String contactId
+    ) {
+        Map<String, String> body = ImmutableMap.of(
+                "OpportunityId", opportunityId,
+                "ContactId", contactId
+        );
+
+        return Async.toSingle(
+                rest.exchange(
+                        makeUri(baseUrl, sfOpportunityContactLinkPath),
+                        HttpMethod.POST,
+                        new HttpEntity<>(body, headers),
+                        String.class
+                )
+        );
+    }
+
+    ///////////////////////////////////////////////////////////////////
+    // Add Conversation Action methods
+    ///////////////////////////////////////////////////////////////////
+
+    @PostMapping(
+            path = ADD_CONVERSATIONS_PATH,
+            consumes = APPLICATION_FORM_URLENCODED_VALUE
+    )
+    public Single<ResponseEntity<Void>> addEmailConversation(
+            @RequestHeader(SALESFORCE_AUTH_HEADER) String auth,
+            @RequestHeader(SALESFORCE_BASE_URL_HEADER) String baseUrl,
+            @RequestParam("user_email") String userEmail,
+            @RequestParam("contact_email") String contactEmail,
+            @RequestParam("email_conversations") String conversations,
+            @RequestParam("attachment_name") String attachmentName,
+            @RequestParam("opportunity_ids") Set<String> opportunityIds
+    ) throws IOException {
+
+        byte[] formattedConversations = formatConversations(conversations).getBytes(StandardCharsets.UTF_8);
+
+        return retrieveContactIds(auth, baseUrl, userEmail, contactEmail)
+                .map(ResponseEntity::getBody)
+                .map(body -> body.<List<String>>read("$..Id"))
+                .map(contactIds -> contactIds.get(0))
+                .flatMap(
+                        contactId ->
+                                linkContactIdToOpportunity(
+                                        contactId,
+                                        opportunityIds,
+                                        formattedConversations,
+                                        attachmentName,
+                                        baseUrl,
+                                        auth
+                                )
+                )
+                .map(ignored -> ResponseEntity.ok().build());
+    }
+
+    private String formatConversations(String conversations) throws IOException {
+        return MessageThread
+                .parse(conversations)
+                .getMessages()
+                .stream()
+                .map(this::formatSingleMessage)
+                .collect(Collectors.joining("\n"));
     }
 
     private String formatSingleMessage(Message message) {
-        StringBuilder fmtMessage = new StringBuilder(SIZE);
-        //Adding Sender info
-        StringBuilder senderInfo = new StringBuilder();
-        senderInfo.append("Sender Name:")
-                .append(WHITE_SPACE)
-                .append(message.getSender().getFirstName())
-                .append(WHITE_SPACE)
-                .append(message.getSender().getLastName())
-                .append(NEW_LINE);
-        //Adding Subject
-        StringBuilder subjectInfo = new StringBuilder();
-        subjectInfo.append("Subject:")
-                .append(message.getSubject())
-                .append(NEW_LINE);
-        //Adding Recipient info
-        StringBuilder recipientsInfo = new StringBuilder();
-        recipientsInfo.append(message.getRecipients().stream().
-                map(this::getRecipientInfo).
-                collect((Supplier<StringBuilder>) StringBuilder::new,
-                        (container, element) -> container.append(element)
-                                .append(NEW_LINE), StringBuilder::append));
-        //Adding Date
-        StringBuilder dateInfo = new StringBuilder();
-        dateInfo.append("Date:")
-                .append(message.getSentDate())
-                .append(NEW_LINE);
-        //Adding Text Message
-        StringBuilder messageInfo = new StringBuilder();
-        messageInfo.append("Message:").append(message.getText()).append(NEW_LINE);
-        return fmtMessage.append(senderInfo).append(subjectInfo)
-                .append(recipientsInfo).append(dateInfo)
-                .append(messageInfo).toString();
+        return String.format(
+                "Sender Name: %s %s\n"
+                        + "Subject:%s\n"
+                        + "%s\n" // recipients
+                        + "Date:%s\n"
+                        + "Message:%s\n",
+                message.getSender().getFirstName(),
+                message.getSender().getLastName(),
+                message.getSubject(),
+                formatRecipients(message),
+                message.getSentDate(),
+                message.getText()
+        );
     }
 
-    private String getRecipientInfo(UserRecord userRecord) {
-        StringBuilder recipientInfo = new StringBuilder(SIZE);
-        recipientInfo.append("Recipient Name:").append(WHITE_SPACE).append(userRecord.getFirstName())
-                .append(WHITE_SPACE)
-                .append(userRecord.getLastName())
-                .append(NEW_LINE)
-                .append("Recipient Email:")
-                .append(WHITE_SPACE)
-                .append(userRecord.getEmailAddress());
-        return recipientInfo.toString();
+    private String formatRecipients(Message message) {
+        return message.getRecipients()
+                .stream()
+                .map(this::formatRecipient)
+                .collect(Collectors.joining("\n"));
     }
 
-    // This class is a Memento encapsulating the things we need to know about a Salesforce account.
-    @AutoProperty
-    private static class SFAccount {
-        private final String id;
-        private final String name;
-        private List<SFOpportunity> opportunities;
-
-        SFAccount(String id, String name) {
-            this.id = id;
-            this.name = name;
-        }
-
-        String getId() {
-            return id;
-        }
-
-        String getName() {
-            return name;
-        }
-
-        public List<SFOpportunity> getAccOpportunities() {
-            return opportunities;
-        }
-
-        public void setAccOpportunities(List<SFOpportunity> opportunities) {
-            this.opportunities = opportunities;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return Pojomatic.equals(this, obj);
-        }
-
-        @Override
-        public int hashCode() {
-            return Pojomatic.hashCode(this);
-        }
-
-        @Override
-        public String toString() {
-            return Pojomatic.toString(this);
-        }
+    private String formatRecipient(UserRecord userRecord) {
+        return String.format(
+                "Recipient Name: %s %s\nRecipientEmail: %s",
+                userRecord.getFirstName(),
+                userRecord.getLastName(),
+                userRecord.getEmailAddress()
+        );
     }
 
-    private static class SFOpportunity {
-        private final String id;
-        private final String name;
+    // Only retrieve the contact ID
+    private Single<ResponseEntity<JsonDocument>> retrieveContactIds(
+            String auth,
+            String baseUrl,
+            String userEmail,
+            String contactEmail
+    ) {
+        String contactIdSoql = String.format(QUERY_FMT_CONTACT_ID, contactEmail, userEmail);
 
-        public SFOpportunity(String id, String name) {
-            this.id = id;
-            this.name = name;
-        }
-
-        public String getId() {
-            return id;
-        }
-
-        public String getName() {
-            return name;
-        }
+        return retrieveContacts(auth, baseUrl, contactIdSoql);
     }
+
+    private Single<?> linkContactIdToOpportunity(
+            String contactId,
+            Set<String> opportunityIds,
+            byte[] conversations,
+            String attachmentName,
+            String baseUrl,
+            String auth
+    ) {
+        return Observable
+                .from(opportunityIds)
+                .flatMapSingle(
+                        opportunityId ->
+                                addEmailConversationToOpportunity(
+                                        contactId,
+                                        opportunityId,
+                                        conversations,
+                                        attachmentName,
+                                        auth,
+                                        baseUrl
+                                )
+                )
+                .toSingle();
+    }
+
+    private Single<?> addEmailConversationToOpportunity(
+            String contactId,
+            String opportunityId,
+            byte[] conversation,
+            String attachmentName,
+            String auth,
+            String baseUrl
+    ) {
+        return retrieveOpportunityTaskLink(auth, baseUrl, opportunityId, contactId)
+                .map(ResponseEntity::getBody)
+                .map(body -> body.<String>read("$.id"))
+                .flatMap(parentId -> linkAttachmentToTask(parentId, conversation, attachmentName, baseUrl, auth));
+    }
+
+    private Single<ResponseEntity<JsonDocument>> retrieveOpportunityTaskLink(
+            String auth,
+            String baseUrl,
+            String opportunityId,
+            String contactId
+    ) {
+        HttpHeaders headers = makeJsonHeaders(auth);
+
+        Map<String, String> body = ImmutableMap.of(
+                "WhatId", opportunityId,
+                "Subject", CONVERSATION_TYPE,
+                "WhoId", contactId
+        );
+
+        return Async.toSingle(
+                rest.exchange(
+                        makeUri(baseUrl, sfOpportunityTaskLinkPath),
+                        HttpMethod.POST,
+                        new HttpEntity<>(body, headers),
+                        JsonDocument.class
+                )
+        );
+    }
+
+    private Single<?> linkAttachmentToTask(
+            String parentId,
+            byte[] conversations,
+            String attachmentName,
+            String baseUrl,
+            String auth
+    ) {
+        HttpHeaders headers = makeJsonHeaders(auth);
+
+        Map<String, String> body = ImmutableMap.of(
+                "Body", Base64Utils.encodeToString(conversations),
+                "Name", attachmentName,
+                "ParentId", parentId,
+                "ContentType", TEXT_PLAIN_VALUE
+        );
+
+        return Async.toSingle(
+                rest.exchange(
+                        makeUri(baseUrl, sfAttachmentTasklinkPath),
+                        HttpMethod.POST,
+                        new HttpEntity<>(body, headers),
+                        String.class
+                )
+        );
+    }
+
 }

--- a/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SalesforceController.java
+++ b/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SalesforceController.java
@@ -205,11 +205,7 @@ public class SalesforceController {
         return retrieveContactInfos(auth, baseUrl, user, sender)
                 .map(HttpEntity::getBody)
                 .flatMap(contacts -> getCards(contacts, sender, baseUrl, routingPrefix, headers, user, senderDomain))
-                .map(cards -> {
-                    Cards c = new Cards();
-                    c.getCards().addAll(cards);
-                    return c;
-                })
+                .map(this::toCards)
                 .map(ResponseEntity::ok);
     }
 
@@ -542,6 +538,12 @@ public class SalesforceController {
             }
             actionBuilder.addUserInputField(inputFieldBuilder.build());
         }
+    }
+
+    private Cards toCards(List<Card> cards) {
+        Cards c = new Cards();
+        c.getCards().addAll(cards);
+        return c;
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SalesforceController.java
+++ b/connectors/salesforce/src/main/java/com/vmware/connectors/salesforce/SalesforceController.java
@@ -320,7 +320,6 @@ public class SalesforceController {
             JsonDocument opportunityDetails
     ) {
         // Fill in the opportunity details.
-        // Opportunity amount is an optional field in salesforce.
         int totalOpportunities = opportunityDetails.read("$.totalSize");
 
         for (int oppIndex = 0; oppIndex < totalOpportunities; oppIndex++) {
@@ -340,6 +339,7 @@ public class SalesforceController {
 
             String oppAmount = opportunityDetails.read(oppJsonPathPrefix + "Opportunity.Amount");
 
+            // Opportunity amount is an optional field in salesforce.
             if (StringUtils.isNotBlank(oppAmount)) {
                 cardBodyBuilder.addField(buildGeneralBodyField("senderinfo.opportunity.amount", oppAmount));
             }

--- a/connectors/salesforce/src/test/java/com/vmware/connectors/salesforce/SalesforceControllerTests.java
+++ b/connectors/salesforce/src/test/java/com/vmware/connectors/salesforce/SalesforceControllerTests.java
@@ -169,8 +169,6 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseContactExists, APPLICATION_JSON));
         expectSalesforceRequest(getContactOpportunitySoql(requestFile))
                 .andRespond(withSuccess(sfResponseWithoutAmount, APPLICATION_JSON));
-//        expectSalesforceRequest(getAccountRequestSoql(requestFile))
-//                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
 
         perform(requestCards("abc", requestFile))
                 .andExpect(status().isOk())
@@ -189,8 +187,6 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseContactExists, APPLICATION_JSON));
         expectSalesforceRequest(getContactOpportunitySoql(requestFile))
                 .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
-//        expectSalesforceRequest(getAccountRequestSoql(requestFile))
-//                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
 
         perform(requestCards("abc", requestFile))
                 .andExpect(status().isOk())
@@ -218,8 +214,6 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseLeoDCaprioOpportunities, APPLICATION_JSON));
         expectSalesforceRequest(getAccountOpportunitySoql("001Q0000012glcuIAA"))
                 .andRespond(withSuccess(sfResponseWordHowardOpportunities, APPLICATION_JSON));
-//        expectSalesforceRequest(getContactOpportunitySoql(requestFile))
-//                .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
 
 
         perform(requestCards("abc", requestFile))
@@ -238,8 +232,6 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseContactExists, APPLICATION_JSON));
         expectSalesforceRequest(getContactOpportunitySoql(requestFile))
                 .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
-//        expectSalesforceRequest(getAccountRequestSoql(requestFile))
-//                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
         perform(requestCards("abc", requestFile).header(ACCEPT_LANGUAGE, "xx"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(APPLICATION_JSON_UTF8))
@@ -264,8 +256,6 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseLeoDCaprioOpportunities, APPLICATION_JSON));
          expectSalesforceRequest(getAccountOpportunitySoql("001Q0000012glcuIAA"))
                 .andRespond(withSuccess(sfResponseWordHowardOpportunities, APPLICATION_JSON));
-//        expectSalesforceRequest(getContactOpportunitySoql(requestFile))
-//                .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
 
 
         perform(requestCards("abc", requestFile).header(ACCEPT_LANGUAGE, "xx"))

--- a/connectors/salesforce/src/test/java/com/vmware/connectors/salesforce/SalesforceControllerTests.java
+++ b/connectors/salesforce/src/test/java/com/vmware/connectors/salesforce/SalesforceControllerTests.java
@@ -169,8 +169,8 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseContactExists, APPLICATION_JSON));
         expectSalesforceRequest(getContactOpportunitySoql(requestFile))
                 .andRespond(withSuccess(sfResponseWithoutAmount, APPLICATION_JSON));
-        expectSalesforceRequest(getAccountRequestSoql(requestFile))
-                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
+//        expectSalesforceRequest(getAccountRequestSoql(requestFile))
+//                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
 
         perform(requestCards("abc", requestFile))
                 .andExpect(status().isOk())
@@ -189,8 +189,8 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseContactExists, APPLICATION_JSON));
         expectSalesforceRequest(getContactOpportunitySoql(requestFile))
                 .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
-        expectSalesforceRequest(getAccountRequestSoql(requestFile))
-                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
+//        expectSalesforceRequest(getAccountRequestSoql(requestFile))
+//                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
 
         perform(requestCards("abc", requestFile))
                 .andExpect(status().isOk())
@@ -218,8 +218,8 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseLeoDCaprioOpportunities, APPLICATION_JSON));
         expectSalesforceRequest(getAccountOpportunitySoql("001Q0000012glcuIAA"))
                 .andRespond(withSuccess(sfResponseWordHowardOpportunities, APPLICATION_JSON));
-        expectSalesforceRequest(getContactOpportunitySoql(requestFile))
-                .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
+//        expectSalesforceRequest(getContactOpportunitySoql(requestFile))
+//                .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
 
 
         perform(requestCards("abc", requestFile))
@@ -238,8 +238,8 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseContactExists, APPLICATION_JSON));
         expectSalesforceRequest(getContactOpportunitySoql(requestFile))
                 .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
-        expectSalesforceRequest(getAccountRequestSoql(requestFile))
-                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
+//        expectSalesforceRequest(getAccountRequestSoql(requestFile))
+//                .andRespond(withSuccess(sfResponseAccounts, APPLICATION_JSON));
         perform(requestCards("abc", requestFile).header(ACCEPT_LANGUAGE, "xx"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(APPLICATION_JSON_UTF8))
@@ -264,8 +264,8 @@ public class SalesforceControllerTests extends ControllerTestsBase {
                 .andRespond(withSuccess(sfResponseLeoDCaprioOpportunities, APPLICATION_JSON));
          expectSalesforceRequest(getAccountOpportunitySoql("001Q0000012glcuIAA"))
                 .andRespond(withSuccess(sfResponseWordHowardOpportunities, APPLICATION_JSON));
-        expectSalesforceRequest(getContactOpportunitySoql(requestFile))
-                .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
+//        expectSalesforceRequest(getContactOpportunitySoql(requestFile))
+//                .andRespond(withSuccess(sfResponseContactOpportunities, APPLICATION_JSON));
 
 
         perform(requestCards("abc", requestFile).header(ACCEPT_LANGUAGE, "xx"))

--- a/pmdrules.xml
+++ b/pmdrules.xml
@@ -60,14 +60,11 @@
         <exclude name="UseIndexOfChar"/>
     </rule>
 
-    <!-- Customize NcssCount to have a more reasonable method and class size -->
+    <!-- Customize NcssCount to have a more reasonable method size -->
     <rule ref="category/java/design.xml/NcssCount">
         <properties>
             <property name="methodReportLevel">
-                <value>70</value>
-            </property>
-            <property name="classReportLevel">
-                <value>300</value>
+                <value>16</value>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
* Reorgs the REST calls to be more selective at what we call out to (throughput
  performance via making less wasted calls instead of possible latency
  reduction due to parallel calls for things we won't need)
* Extracts SFAccount and SFOpportunity into their own files
* Makes "private static final" vs. "private final static" consistent
* Reformats constructor, method, and annotation parameters
* Breaks methods down into smaller methods
* Reduces some REST callout and card generation duplication
* Removes unnecessary annotation param names (single default param)
* Removes unnecessary finals (local variables and params in small methods)
* Reorders methods to flow more naturally when reading the code
* Changes code to use a more fluent style
* Changes SFAccount to be immutable

Signed-off-by: John Bard <jbard@vmware.com>