### PR TITLE
APF-786: Fix Bitbucket comment action

### DIFF
--- a/connectors/bitbucket-server/src/main/java/com/vmware/connectors/bitbucket/server/BitbucketServerController.java
+++ b/connectors/bitbucket-server/src/main/java/com/vmware/connectors/bitbucket/server/BitbucketServerController.java
@@ -367,7 +367,7 @@ public class BitbucketServerController {
                         .setUrl(buildActionUrl(routingPrefix, pullRequest, BitbucketServerAction.COMMENTS))
                         .addUserInputField(
                                 new CardActionInputField.Builder()
-                                        .setId("Comment")
+                                        .setId(COMMENT_PARAM_KEY)
                                         .setLabel(this.cardTextAccessor.getMessage(BITBUCKET_SERVER_COMMENTS))
                                         .setMinLength(1)
                                         .build()

--- a/connectors/bitbucket-server/src/test/resources/bitbucket/responses/success.json
+++ b/connectors/bitbucket-server/src/test/resources/bitbucket/responses/success.json
@@ -61,7 +61,7 @@
           "request": {},
           "user_input": [
             {
-              "id": "Comment",
+              "id": "comment",
               "label": "Comment",
               "min_length": 1
             }
@@ -131,7 +131,7 @@
           "request": {},
           "user_input": [
             {
-              "id": "Comment",
+              "id": "comment",
               "label": "Comment",
               "min_length": 1
             }


### PR DESCRIPTION
I didn't notice that https://github.com/vmware/connectors-workspace-one/pull/21#discussion_r164250454 wasn't addressed, so the comments button wasn't working.

This fixes that issue.