### PR TITLE
APF-792: Fix AWSCert approve path

### DIFF
--- a/connectors/aws-cert/src/main/java/com/vmware/connectors/aws/cert/AwsCertController.java
+++ b/connectors/aws-cert/src/main/java/com/vmware/connectors/aws/cert/AwsCertController.java
@@ -251,7 +251,7 @@ public class AwsCertController {
                 .setLabel(cardTextAccessor.getActionLabel("approve"))
                 .setCompletedLabel(cardTextAccessor.getActionCompletedLabel("approve"))
                 .setActionKey(CardActionKey.DIRECT)
-                .setUrl(routingPrefix + APPROVE_PATH)
+                .setUrl(routingPrefix + APPROVE_PATH.substring(1))
                 .setType(HttpMethod.POST);
 
         info.getFormParams().forEach(approveAction::addRequestParam);

--- a/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/card.json
+++ b/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/card.json
@@ -42,7 +42,7 @@
           "id": "00000000-0000-0000-0000-000000000000",
           "label": "Approve",
           "url": {
-            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+            "href": "https://hero/connectors/aws-cert/api/v1/approve"
           },
           "type": "POST",
           "action_key": "DIRECT",
@@ -101,7 +101,7 @@
           "id": "00000000-0000-0000-0000-000000000000",
           "label": "Approve",
           "url": {
-            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+            "href": "https://hero/connectors/aws-cert/api/v1/approve"
           },
           "type": "POST",
           "action_key": "DIRECT",
@@ -160,7 +160,7 @@
           "id": "00000000-0000-0000-0000-000000000000",
           "label": "Approve",
           "url": {
-            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+            "href": "https://hero/connectors/aws-cert/api/v1/approve"
           },
           "type": "POST",
           "action_key": "DIRECT",

--- a/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/card_xx.json
+++ b/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/card_xx.json
@@ -42,7 +42,7 @@
           "id": "00000000-0000-0000-0000-000000000000",
           "label": "APPROVE",
           "url": {
-            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+            "href": "https://hero/connectors/aws-cert/api/v1/approve"
           },
           "type": "POST",
           "action_key": "DIRECT",
@@ -101,7 +101,7 @@
           "id": "00000000-0000-0000-0000-000000000000",
           "label": "APPROVE",
           "url": {
-            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+            "href": "https://hero/connectors/aws-cert/api/v1/approve"
           },
           "type": "POST",
           "action_key": "DIRECT",
@@ -160,7 +160,7 @@
           "id": "00000000-0000-0000-0000-000000000000",
           "label": "APPROVE",
           "url": {
-            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+            "href": "https://hero/connectors/aws-cert/api/v1/approve"
           },
           "type": "POST",
           "action_key": "DIRECT",

--- a/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/single-card.json
+++ b/connectors/aws-cert/src/test/resources/awscert/responses/success/cards/single-card.json
@@ -42,7 +42,7 @@
           "id": "00000000-0000-0000-0000-000000000000",
           "label": "Approve",
           "url": {
-            "href": "https://hero/connectors/aws-cert//api/v1/approve"
+            "href": "https://hero/connectors/aws-cert/api/v1/approve"
           },
           "type": "POST",
           "action_key": "DIRECT",


### PR DESCRIPTION
Some refactoring of some constants to reduce duplication ended up with the
double slash before "api", which shouldn't have been a problem, but something
wasn't allowing it through.  This commit fixes that issue.

Signed-off-by: John Bard <jbard@vmware.com>