### PR TITLE
APF-797: Add info to ServiceNow cards

### DIFF
--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ApprovalRequestWithInfo.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ApprovalRequestWithInfo.java
@@ -9,17 +9,17 @@ import org.pojomatic.Pojomatic;
 import org.pojomatic.annotations.AutoProperty;
 
 @AutoProperty
-class ApprovalRequestWithNumber extends ApprovalRequest {
+class ApprovalRequestWithInfo extends ApprovalRequest {
 
-    private final String number;
+    private final Request info;
 
     /**
      * @param request The {@link ApprovalRequest} information from the sysapproval_approver record.
-     * @param number The request number from the sc_request record.
+     * @param info The request infofrom the sc_request record.
      */
-    ApprovalRequestWithNumber(
+    ApprovalRequestWithInfo(
             ApprovalRequest request,
-            String number
+            Request info
     ) {
         super(
                 request.getRequestSysId(),
@@ -28,14 +28,14 @@ class ApprovalRequestWithNumber extends ApprovalRequest {
                 request.getDueDate(),
                 request.getCreatedBy()
         );
-        this.number = number;
+        this.info = info;
     }
 
     /**
-     * @return The request number from the sc_request record.
+     * @return The request info from the sc_request record.
      */
-    String getNumber() {
-        return number;
+    Request getInfo() {
+        return info;
     }
 
     @Override

--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ApprovalRequestWithItems.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ApprovalRequestWithItems.java
@@ -1,0 +1,31 @@
+package com.vmware.connectors.servicenow;
+
+import com.google.common.collect.ImmutableList;
+import org.pojomatic.Pojomatic;
+import org.pojomatic.annotations.AutoProperty;
+
+import java.util.List;
+
+@AutoProperty
+class ApprovalRequestWithItems extends ApprovalRequestWithInfo {
+
+    private final List<RequestedItem> items;
+
+    ApprovalRequestWithItems(
+            ApprovalRequestWithInfo request,
+            List<RequestedItem> items
+    ) {
+        super(request, request.getInfo());
+        this.items = ImmutableList.copyOf(items);
+    }
+
+    List<RequestedItem> getItems() {
+        return items;
+    }
+
+    @Override
+    public String toString() {
+        return Pojomatic.toString(this);
+    }
+
+}

--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/Request.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/Request.java
@@ -1,0 +1,33 @@
+package com.vmware.connectors.servicenow;
+
+import org.pojomatic.Pojomatic;
+import org.pojomatic.annotations.AutoProperty;
+
+@AutoProperty
+class Request {
+
+    private final String number;
+    private final String totalPrice;
+
+    Request(
+            String number,
+            String totalPrice
+    ) {
+        this.number = number;
+        this.totalPrice = totalPrice;
+    }
+
+    String getNumber() {
+        return number;
+    }
+
+    String getTotalPrice() {
+        return totalPrice;
+    }
+
+    @Override
+    public String toString() {
+        return Pojomatic.toString(this);
+    }
+
+}

--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/RequestedItem.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/RequestedItem.java
@@ -1,0 +1,54 @@
+package com.vmware.connectors.servicenow;
+
+import org.pojomatic.Pojomatic;
+import org.pojomatic.annotations.AutoProperty;
+
+@AutoProperty
+class RequestedItem {
+
+    private final String sysId;
+    private final String requestSysId;
+    private final String shortDescription;
+    private final String price;
+    private final String quantity;
+
+    RequestedItem(
+            String sysId,
+            String requestSysId,
+            String shortDescription,
+            String price,
+            String quantity
+    ) {
+        this.sysId = sysId;
+        this.requestSysId = requestSysId;
+        this.shortDescription = shortDescription;
+        this.price = price;
+        this.quantity = quantity;
+    }
+
+    String getSysId() {
+        return sysId;
+    }
+
+    String getRequestSysId() {
+        return requestSysId;
+    }
+
+    String getShortDescription() {
+        return shortDescription;
+    }
+
+    String getPrice() {
+        return price;
+    }
+
+    String getQuantity() {
+        return quantity;
+    }
+
+    @Override
+    public String toString() {
+        return Pojomatic.toString(this);
+    }
+
+}

--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ScRequest.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ScRequest.java
@@ -8,9 +8,9 @@ package com.vmware.connectors.servicenow;
 /**
  * A class to hold API information (fields, states, etc.) for ServiceNow's sc_request table.
  */
-public final class ScRequest {
+final class ScRequest {
 
-    public enum Fields {
+    enum Fields {
 
         /**
          * The system id for an item in the sc_request table.
@@ -18,6 +18,13 @@ public final class ScRequest {
          * Example: 6eed229047801200e0ef563dbb9a71c2
          */
         SYS_ID("sys_id"),
+
+        /**
+         * The total price of the request.
+         *
+         * Example: 3349.95
+         */
+        PRICE("price"),
 
         /**
          * The request number.
@@ -42,7 +49,7 @@ public final class ScRequest {
     /**
      * The name of the request table in ServiceNow.
      */
-    public static final String TABLE_NAME = "sc_request";
+    static final String TABLE_NAME = "sc_request";
 
     private ScRequest() {
         // empty: utility class

--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ScRequestedItem.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/ScRequestedItem.java
@@ -1,0 +1,67 @@
+package com.vmware.connectors.servicenow;
+
+/**
+ * A class to hold API information (fields, states, etc.) for ServiceNow's sc_req_item table.
+ */
+final class ScRequestedItem {
+
+    enum Fields {
+
+        /**
+         * The system id for an item in the sc_req_item table.
+         *
+         * Example: aeed229047801200e0ef563dbb9a71c2
+         */
+        SYS_ID("sys_id"),
+
+        /**
+         * The request associated with the item being requested.
+         *
+         * Example: { "link": "https://dev15329.service-now.com/api/now/table/sc_request/6eed229047801200e0ef563dbb9a71c2", "value": "6eed229047801200e0ef563dbb9a71c2"}
+         */
+        REQUEST("request"),
+
+        /**
+         * The description of the item being requested.
+         *
+         * Example: Apple iPad 3
+         */
+        SHORT_DESCRIPTION("short_description"),
+
+        /**
+         * The price of the item being requested.
+         *
+         * Example: 600.00
+         */
+        PRICE("price"),
+
+        /**
+         * The quantity of item being requested.
+         *
+         * Example: 5
+         */
+        QUANTITY("quantity");
+
+        private final String snowField;
+
+        Fields(String snowField) {
+            this.snowField = snowField;
+        }
+
+        @Override
+        public String toString() {
+            return this.snowField;
+        }
+
+    }
+
+    /**
+     * The name of the requested item table in ServiceNow.
+     */
+    static final String TABLE_NAME = "sc_req_item";
+
+    private ScRequestedItem() {
+        // empty: utility class
+    }
+
+}

--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/SysApprovalApprover.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/SysApprovalApprover.java
@@ -8,9 +8,9 @@ package com.vmware.connectors.servicenow;
 /**
  * A class to hold API information (fields, states, etc.) for ServiceNow's sysapproval_approver table.
  */
-public final class SysApprovalApprover {
+final class SysApprovalApprover {
 
-    public enum Fields {
+    enum Fields {
 
         /**
          * The system id for an item in the sysapproval_approver table.
@@ -82,7 +82,7 @@ public final class SysApprovalApprover {
 
     }
 
-    public enum States {
+    enum States {
 
         /**
          * The approval request has been submitted, but not approved or rejected yet.
@@ -115,7 +115,7 @@ public final class SysApprovalApprover {
     /**
      * The name of the table for approval requests in ServiceNow.
      */
-    public static final String TABLE_NAME = "sysapproval_approver";
+    static final String TABLE_NAME = "sysapproval_approver";
 
     private SysApprovalApprover() {
         // empty: utility class

--- a/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/SysUser.java
+++ b/connectors/servicenow/src/main/java/com/vmware/connectors/servicenow/SysUser.java
@@ -8,9 +8,9 @@ package com.vmware.connectors.servicenow;
 /**
  * A class to hold API information (fields, states, etc.) for ServiceNow's sys_user table.
  */
-public final class SysUser {
+final class SysUser {
 
-    public enum Fields {
+    enum Fields {
 
         /**
          * The system id for an item in the sys_user table.
@@ -49,7 +49,7 @@ public final class SysUser {
     /**
      * The name of the user table in ServiceNow.
      */
-    public static final String TABLE_NAME = "sys_user";
+    static final String TABLE_NAME = "sys_user";
 
     private SysUser() {
         // empty: utility class

--- a/connectors/servicenow/src/main/resources/cards/text.properties
+++ b/connectors/servicenow/src/main/resources/cards/text.properties
@@ -1,13 +1,16 @@
-header=Approval Requested For {0}
-subtitle=Approval Request
+header=Approval Request - {0}
 
-body=A request requires your approval. {0} was submitted by {1} and is due by {2}.
-requestNumber.title=Ticket Number
-requestNumber.description={0}
+totalPrice.title=Total Price
+totalPrice.description=${0}
+
 createdBy.title=Requester
 createdBy.description={0}
+
 dueDate.title=Due By
 dueDate.description={0}
+
+items.title=Items
+items.line={0} - {1} @ ${2}
 
 approve.label=Approve
 approve.completedLabel=Approved

--- a/connectors/servicenow/src/test/java/com/vmware/connectors/servicenow/ServiceNowControllerTests.java
+++ b/connectors/servicenow/src/test/java/com/vmware/connectors/servicenow/ServiceNowControllerTests.java
@@ -186,20 +186,30 @@ public class ServiceNowControllerTests extends ControllerTestsBase {
                 .andExpect(method(GET))
                 .andRespond(withSuccess(fromFile("/servicenow/fake/approval-requests.json"), APPLICATION_JSON));
 
-        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_request/test-sc-request-id-1?sysparm_fields=sys_id,number"))
+        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_request/test-sc-request-id-1?sysparm_fields=sys_id,price,number"))
                 .andExpect(header(AUTHORIZATION, "Bearer " + SNOW_AUTH_TOKEN))
                 .andExpect(method(GET))
                 .andRespond(withSuccess(fromFile("/servicenow/fake/request-1.json"), APPLICATION_JSON));
 
-        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_request/test-sc-request-id-2?sysparm_fields=sys_id,number"))
+        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_request/test-sc-request-id-2?sysparm_fields=sys_id,price,number"))
                 .andExpect(header(AUTHORIZATION, "Bearer " + SNOW_AUTH_TOKEN))
                 .andExpect(method(GET))
                 .andRespond(withSuccess(fromFile("/servicenow/fake/request-2.json"), APPLICATION_JSON));
 
-        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_request/test-sc-request-id-3?sysparm_fields=sys_id,number"))
+        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_request/test-sc-request-id-3?sysparm_fields=sys_id,price,number"))
                 .andExpect(header(AUTHORIZATION, "Bearer " + SNOW_AUTH_TOKEN))
                 .andExpect(method(GET))
                 .andRespond(withSuccess(fromFile("/servicenow/fake/request-3.json"), APPLICATION_JSON));
+
+        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_req_item?sysparm_fields=sys_id,price,request,short_description,quantity&sysparm_limit=10000&request=test-sc-request-id-2"))
+                .andExpect(header(AUTHORIZATION, "Bearer " + SNOW_AUTH_TOKEN))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(fromFile("/servicenow/fake/requested-items-2.json"), APPLICATION_JSON));
+
+        mockServiceNow.expect(requestTo("https://snow.acme.com/api/now/table/sc_req_item?sysparm_fields=sys_id,price,request,short_description,quantity&sysparm_limit=10000&request=test-sc-request-id-3"))
+                .andExpect(header(AUTHORIZATION, "Bearer " + SNOW_AUTH_TOKEN))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(fromFile("/servicenow/fake/requested-items-3.json"), APPLICATION_JSON));
     }
 
     @Test

--- a/connectors/servicenow/src/test/resources/cards/text_xx.properties
+++ b/connectors/servicenow/src/test/resources/cards/text_xx.properties
@@ -1,17 +1,20 @@
-header={0} roF detseuqeR lavorppA
-subtitle=tseuqeR lavorppA
+header=APPROVAL REQUEST - {0}
 
-body=.{2} yb eud si dna {1} yb dettimbus saw {0} .lavorppa ruoy seriuqer tseuqer A
-requestNumber.title=rebmuN tekciT
-requestNumber.description={0}
-createdBy.title=retseuqeR
+totalPrice.title=TOTAL PRICE
+totalPrice.description=${0}
+
+createdBy.title=REQUESTER
 createdBy.description={0}
-dueDate.title=yB euD
+
+dueDate.title=DUE BY
 dueDate.description={0}
 
-approve.label=evorppA
-approve.completedLabel=devorppA
+items.title=ITEMS
+items.line={0} - {1} @ ${2}
 
-reject.label=tcejeR
-reject.completedLabel=detcejeR
-reject.reason.label=noitcejer rof nosaeR
+approve.label=APPROVE
+approve.completedLabel=APPROVED
+
+reject.label=REJECT
+reject.completedLabel=REJECTED
+reject.reason.label=REASON FOR REJECTION

--- a/connectors/servicenow/src/test/resources/servicenow/fake/request-1.json
+++ b/connectors/servicenow/src/test/resources/servicenow/fake/request-1.json
@@ -1,6 +1,7 @@
 {
   "result": {
     "sys_id": "test-sc-request-id-1",
+    "price": "100.99",
     "number": "REQ0010001"
   }
 }

--- a/connectors/servicenow/src/test/resources/servicenow/fake/request-2.json
+++ b/connectors/servicenow/src/test/resources/servicenow/fake/request-2.json
@@ -1,6 +1,7 @@
 {
   "result": {
     "sys_id": "test-sc-request-id-2",
+    "price": "401.98",
     "number": "REQ0010002"
   }
 }

--- a/connectors/servicenow/src/test/resources/servicenow/fake/request-3.json
+++ b/connectors/servicenow/src/test/resources/servicenow/fake/request-3.json
@@ -1,6 +1,7 @@
 {
   "result": {
     "sys_id": "test-sc-request-id-3",
+    "price": "902.97",
     "number": "REQ0010003"
   }
 }

--- a/connectors/servicenow/src/test/resources/servicenow/fake/requested-items-2.json
+++ b/connectors/servicenow/src/test/resources/servicenow/fake/requested-items-2.json
@@ -1,0 +1,14 @@
+{
+  "result": [
+    {
+      "price": "200.99",
+      "request": {
+        "link": "http://something/task/test-sc-request-id-2",
+        "value": "test-sc-request-id-2"
+      },
+      "short_description": "Apple iPhone 6",
+      "sys_id": "test-sc-req-item-id-2",
+      "quantity": "2"
+    }
+  ]
+}

--- a/connectors/servicenow/src/test/resources/servicenow/fake/requested-items-3.json
+++ b/connectors/servicenow/src/test/resources/servicenow/fake/requested-items-3.json
@@ -1,0 +1,14 @@
+{
+  "result": [
+    {
+      "price": "300.99",
+      "request": {
+        "link": "http://something/task/test-sc-request-id-3",
+        "value": "test-sc-request-id-3"
+      },
+      "short_description": "Samsung Galaxy S7 Edge",
+      "sys_id": "test-sc-req-item-id-3",
+      "quantity": "3"
+    }
+  ]
+}

--- a/connectors/servicenow/src/test/resources/servicenow/responses/success/cards/card.json
+++ b/connectors/servicenow/src/test/resources/servicenow/responses/success/cards/card.json
@@ -8,16 +8,14 @@
         "href": "https://hero/connectors/servicenow/templates/generic.hbs"
       },
       "header": {
-        "title": "Approval Requested For REQ0010002",
-        "subtitle": "Approval Request"
+        "title": "Approval Request - REQ0010002"
       },
       "body": {
-        "description": "A request requires your approval. REQ0010002 was submitted by test-request-user-2 and is due by test-due-date-2.",
         "fields": [
           {
-            "title": "Ticket Number",
+            "title": "Total Price",
             "type": "GENERAL",
-            "description": "REQ0010002"
+            "description": "$401.98"
           },
           {
             "title": "Requester",
@@ -28,6 +26,15 @@
             "title": "Due By",
             "type": "GENERAL",
             "description": "test-due-date-2"
+          },
+          {
+            "title": "Items",
+            "type": "COMMENT",
+            "content": [
+              {
+                "text": "Apple iPhone 6 - 2 @ $200.99"
+              }
+            ]
           }
         ]
       },
@@ -72,16 +79,14 @@
         "href": "https://hero/connectors/servicenow/templates/generic.hbs"
       },
       "header": {
-        "title": "Approval Requested For REQ0010003",
-        "subtitle": "Approval Request"
+        "title": "Approval Request - REQ0010003"
       },
       "body": {
-        "description": "A request requires your approval. REQ0010003 was submitted by test-request-user-3 and is due by test-due-date-3.",
         "fields": [
           {
-            "title": "Ticket Number",
+            "title": "Total Price",
             "type": "GENERAL",
-            "description": "REQ0010003"
+            "description": "$902.97"
           },
           {
             "title": "Requester",
@@ -92,6 +97,15 @@
             "title": "Due By",
             "type": "GENERAL",
             "description": "test-due-date-3"
+          },
+          {
+            "title": "Items",
+            "type": "COMMENT",
+            "content": [
+              {
+                "text": "Samsung Galaxy S7 Edge - 3 @ $300.99"
+              }
+            ]
           }
         ]
       },

--- a/connectors/servicenow/src/test/resources/servicenow/responses/success/cards/card_xx.json
+++ b/connectors/servicenow/src/test/resources/servicenow/responses/success/cards/card_xx.json
@@ -8,34 +8,41 @@
         "href": "https://hero/connectors/servicenow/templates/generic.hbs"
       },
       "header": {
-        "title": "REQ0010002 roF detseuqeR lavorppA",
-        "subtitle": "tseuqeR lavorppA"
+        "title": "APPROVAL REQUEST - REQ0010002"
       },
       "body": {
-        "description": ".test-due-date-2 yb eud si dna test-request-user-2 yb dettimbus saw REQ0010002 .lavorppa ruoy seriuqer tseuqer A",
         "fields": [
           {
-            "title": "rebmuN tekciT",
+            "title": "TOTAL PRICE",
             "type": "GENERAL",
-            "description": "REQ0010002"
+            "description": "$401.98"
           },
           {
-            "title": "retseuqeR",
+            "title": "REQUESTER",
             "type": "GENERAL",
             "description": "test-request-user-2"
           },
           {
-            "title": "yB euD",
+            "title": "DUE BY",
             "type": "GENERAL",
             "description": "test-due-date-2"
+          },
+          {
+            "title": "ITEMS",
+            "type": "COMMENT",
+            "content": [
+              {
+                "text": "Apple iPhone 6 - 2 @ $200.99"
+              }
+            ]
           }
         ]
       },
       "actions": [
         {
           "id": "00000000-0000-0000-0000-000000000000",
-          "label": "evorppA",
-          "completed_label": "devorppA",
+          "label": "APPROVE",
+          "completed_label": "APPROVED",
           "url": {
             "href": "https://hero/connectors/servicenow/api/v1/tickets/test-ticket-id-2/approve"
           },
@@ -46,8 +53,8 @@
         },
         {
           "id": "00000000-0000-0000-0000-000000000000",
-          "label": "tcejeR",
-          "completed_label": "detcejeR",
+          "label": "REJECT",
+          "completed_label": "REJECTED",
           "url": {
             "href": "https://hero/connectors/servicenow/api/v1/tickets/test-ticket-id-2/reject"
           },
@@ -57,7 +64,7 @@
           "user_input": [
             {
               "id": "reason",
-              "label": "noitcejer rof nosaeR",
+              "label": "REASON FOR REJECTION",
               "min_length": 1
             }
           ]
@@ -72,34 +79,41 @@
         "href": "https://hero/connectors/servicenow/templates/generic.hbs"
       },
       "header": {
-        "title": "REQ0010003 roF detseuqeR lavorppA",
-        "subtitle": "tseuqeR lavorppA"
+        "title": "APPROVAL REQUEST - REQ0010003"
       },
       "body": {
-        "description": ".test-due-date-3 yb eud si dna test-request-user-3 yb dettimbus saw REQ0010003 .lavorppa ruoy seriuqer tseuqer A",
         "fields": [
           {
-            "title": "rebmuN tekciT",
+            "title": "TOTAL PRICE",
             "type": "GENERAL",
-            "description": "REQ0010003"
+            "description": "$902.97"
           },
           {
-            "title": "retseuqeR",
+            "title": "REQUESTER",
             "type": "GENERAL",
             "description": "test-request-user-3"
           },
           {
-            "title": "yB euD",
+            "title": "DUE BY",
             "type": "GENERAL",
             "description": "test-due-date-3"
+          },
+          {
+            "title": "ITEMS",
+            "type": "COMMENT",
+            "content": [
+              {
+                "text": "Samsung Galaxy S7 Edge - 3 @ $300.99"
+              }
+            ]
           }
         ]
       },
       "actions": [
         {
           "id": "00000000-0000-0000-0000-000000000000",
-          "label": "evorppA",
-          "completed_label": "devorppA",
+          "label": "APPROVE",
+          "completed_label": "APPROVED",
           "url": {
             "href": "https://hero/connectors/servicenow/api/v1/tickets/test-ticket-id-3/approve"
           },
@@ -110,8 +124,8 @@
         },
         {
           "id": "00000000-0000-0000-0000-000000000000",
-          "label": "tcejeR",
-          "completed_label": "detcejeR",
+          "label": "REJECT",
+          "completed_label": "REJECTED",
           "url": {
             "href": "https://hero/connectors/servicenow/api/v1/tickets/test-ticket-id-3/reject"
           },
@@ -121,7 +135,7 @@
           "user_input": [
             {
               "id": "reason",
-              "label": "noitcejer rof nosaeR",
+              "label": "REASON FOR REJECTION",
               "min_length": 1
             }
           ]


### PR DESCRIPTION
* Adds total price and requested items to ServiceNow cards
* Removes redundant and unnecessary information

Signed-off-by: John Bard <jbard@vmware.com>