### PR TITLE
APF-838-Change Authorization prefix from Bearer to OAuth for concur

### DIFF
--- a/connectors/concur/src/main/java/com/vmware/connectors/concur/ConcurController.java
+++ b/connectors/concur/src/main/java/com/vmware/connectors/concur/ConcurController.java
@@ -72,8 +72,14 @@ public class ConcurController {
             return Single.just(ResponseEntity.ok(new Cards()));
         }
 
+        /*
+         * TODO: Remove the below line when we start using concur 3.0 API. Currently, concur 2.0 API uses custom OAuth
+         * and we have to send the authorization header with "OAuth" prefix instead of "Bearer".
+         */
+        final String modifiedAuthHeader = authHeader.replace("Bearer", "OAuth");
+
         final HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, authHeader);
+        headers.set(AUTHORIZATION, modifiedAuthHeader);
         headers.set(ACCEPT, APPLICATION_JSON_VALUE);
 
         return Observable.from(expenseReportIds)
@@ -114,8 +120,14 @@ public class ConcurController {
                                                                  final String reportID,
                                                                  final String authHeader,
                                                                  final String concurAction) throws IOException, ExecutionException, InterruptedException {
+        /*
+         * TODO: Remove the below line when we start using concur 3.0 API. Currently, concur 2.0 API uses custom OAuth
+         * and we have to send the authorization header with "OAuth" prefix instead of "Bearer".
+         */
+        final String modifiedAuthHeader = authHeader.replace("Bearer", "OAuth");
+
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(AUTHORIZATION, authHeader);
+        headers.add(AUTHORIZATION, modifiedAuthHeader);
         headers.add(CONTENT_TYPE, APPLICATION_XML_VALUE);
         headers.add(ACCEPT, APPLICATION_JSON_VALUE);
 

--- a/connectors/concur/src/test/java/com/vmware/connectors/concur/ConcurControllerTests.java
+++ b/connectors/concur/src/test/java/com/vmware/connectors/concur/ConcurControllerTests.java
@@ -34,7 +34,8 @@ import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -147,7 +148,7 @@ public class ConcurControllerTests extends ControllerTestsBase {
         perform(post(uri + expenseReportId)
                 .with(token(accessToken()))
                 .contentType(APPLICATION_FORM_URLENCODED_VALUE)
-                .header("x-concur-authorization", "OAuth " + "0_xxxxEKPk8cnYlWaos22OpPsLk=")
+                .header("x-concur-authorization", "Bearer " + "0_xxxxEKPk8cnYlWaos22OpPsLk=")
                 .header("x-concur-base-url", "https://implementation.concursolutions.com")
                 .param(ConcurConstants.RequestParam.REASON, "Approval Done"))
                 .andExpect(status().isOk());
@@ -270,7 +271,7 @@ public class ConcurControllerTests extends ControllerTestsBase {
         return post("/cards/requests").with(token(accessToken()))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
-                .header("x-concur-authorization", "OAuth " + authToken)
+                .header("x-concur-authorization", "Bearer " + authToken)
                 .header("x-concur-base-url", "https://implementation.concursolutions.com")
                 .header("x-routing-prefix", "https://hero/connectors/concur/")
                 .content(fromFile("/concur/requests/" + requestFile));


### PR DESCRIPTION
Currently, concur 2.0 API uses custom OAuth and we have to send the authorization header with "OAuth" prefix instead of "Bearer".
         