### PR TITLE
APF-970: Add capture_group to regex metadata

### DIFF
--- a/common/connectors-test/src/main/java/com/vmware/connectors/test/ControllerTestsBase.java
+++ b/common/connectors-test/src/main/java/com/vmware/connectors/test/ControllerTestsBase.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -161,18 +162,19 @@ public class ControllerTestsBase {
             Map<String, Object> fields = (Map<String, Object>) results.get("fields");
             Map<String, Object> tokenDefinition = (Map<String, Object>) fields.get(tokenProperty);
             String regex = (String) tokenDefinition.get("regex");
-            verifyRegex(regex, emailInput, expected);
+            Integer captureGroup = (Integer) tokenDefinition.get("capture_group");
+            verifyRegex(regex, captureGroup, emailInput, expected);
         });
     }
 
-    private void verifyRegex(String regex, String emailInput, List<String> expected) throws Exception {
+    private void verifyRegex(String regex, Integer captureGroup, String emailInput, List<String> expected) throws Exception {
         Pattern pattern = Pattern.compile(regex);
 
         List<String> results = new ArrayList<>();
         for (String line : emailInput.split("\\n")) {
             Matcher matcher = pattern.matcher("\n" + line);
             while (matcher.find()) {
-                results.add(matcher.group(1));
+                results.add(matcher.group(Optional.ofNullable(captureGroup).orElse(0)));
             }
         }
 

--- a/connectors/airwatch/src/main/resources/static/discovery/metadata.json
+++ b/connectors/airwatch/src/main/resources/static/discovery/metadata.json
@@ -8,6 +8,7 @@
       "env": "DEVICE_SYSTEM_NAME"
     },
     "app_keywords": {
+      "capture_group": 1,
       "regex": "(CONNECTOR_REGEX)"
     }
   }

--- a/connectors/airwatch/src/test/resources/connector/responses/metadata.json
+++ b/connectors/airwatch/src/test/resources/connector/responses/metadata.json
@@ -8,6 +8,7 @@
       "env": "DEVICE_SYSTEM_NAME"
     },
     "app_keywords": {
+      "capture_group": 1,
       "regex": "((?i)boxer|concur|poison)"
     }
   }

--- a/connectors/aws-cert/src/main/resources/static/discovery/metadata.json
+++ b/connectors/aws-cert/src/main/resources/static/discovery/metadata.json
@@ -1,6 +1,7 @@
 {
   "fields": {
     "approval_urls": {
+      "capture_group": 1,
       "regex": "Certificate Approvals \\( ([^)]+) \\)"
     }
   }

--- a/connectors/bitbucket-server/src/main/resources/static/discovery/metadata.json
+++ b/connectors/bitbucket-server/src/main/resources/static/discovery/metadata.json
@@ -3,6 +3,7 @@
   "backend_base_url_header": "x-bitbucket-server-base-url",
   "fields": {
     "pr_email_subject": {
+      "capture_group": 1,
       "regex": "((?:[a-zA-Z0-9]+)\/(?:[a-zA-Z0-9-]+) - Pull request #(?:[0-9]+):[ ])"
     }
   }

--- a/connectors/concur/src/main/resources/static/discovery/metadata.json
+++ b/connectors/concur/src/main/resources/static/discovery/metadata.json
@@ -3,6 +3,7 @@
   "backend_base_url_header": "x-concur-base-url",
   "fields": {
     "expense_report_id": {
+      "capture_group": 1,
       "regex": "Report\\s*Id\\s*:\\s*([A-Za-z0-9]{20,})"
     }
   }

--- a/connectors/github-pr/src/main/resources/static/discovery/metadata.json
+++ b/connectors/github-pr/src/main/resources/static/discovery/metadata.json
@@ -3,6 +3,7 @@
   "backend_base_url_header": "x-github-pr-base-url",
   "fields": {
     "pull_request_urls": {
+      "capture_group": 1,
       "regex": "(https://github.com/[a-zA-Z0-9-]+/[a-zA-Z0-9._-]+/pull/[0-9]+)"
     }
   }

--- a/connectors/gitlab-pr/src/main/resources/static/discovery/metadata.json
+++ b/connectors/gitlab-pr/src/main/resources/static/discovery/metadata.json
@@ -3,6 +3,7 @@
   "backend_base_url_header": "x-gitlab-pr-base-url",
   "fields": {
     "merge_request_urls": {
+      "capture_group": 1,
       "regex": "(https://gitlab.com/[a-zA-Z0-9-]+/[a-zA-Z0-9._-]+/merge_requests/[0-9]+)"
     }
   }

--- a/connectors/jira/src/main/resources/static/discovery/metadata.json
+++ b/connectors/jira/src/main/resources/static/discovery/metadata.json
@@ -3,6 +3,7 @@
   "backend_base_url_header": "x-jira-base-url",
   "fields": {
     "issue_id": {
+      "capture_group": 1,
       "regex": "[\\W]([A-Z]{1,10}-\\d+)"
     }
   }

--- a/connectors/salesforce/src/main/resources/static/discovery/metadata.json
+++ b/connectors/salesforce/src/main/resources/static/discovery/metadata.json
@@ -6,6 +6,7 @@
       "env": "USER_EMAIL"
     },
     "sender_email": {
+      "capture_group": 1,
       "regex": "([A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6})"
     }
   }

--- a/connectors/servicenow/src/main/resources/static/discovery/metadata.json
+++ b/connectors/servicenow/src/main/resources/static/discovery/metadata.json
@@ -2,7 +2,12 @@
   "authorization_header": "x-servicenow-authorization",
   "backend_base_url_header": "x-servicenow-base-url",
   "fields": {
-    "ticket_id": {"regex": "(REQ[0-9]{7})"},
-    "email": {"env": "USER_EMAIL"}
+    "ticket_id": {
+      "capture_group": 1,
+      "regex": "(REQ[0-9]{7})"
+    },
+    "email": {
+      "env": "USER_EMAIL"
+    }
   }
 }


### PR DESCRIPTION
* Changes regex test code to do closer to what the client will do
* Adds capture_group to all connectors' metadata.json files

Signed-off-by: John Bard <jbard@vmware.com>