### PR TITLE
APF-1011: Fix AirWatch Connector

### DIFF
--- a/common/core/src/main/java/com/vmware/connectors/common/json/JsonDocumentDecoder.java
+++ b/common/core/src/main/java/com/vmware/connectors/common/json/JsonDocumentDecoder.java
@@ -11,6 +11,7 @@ import org.apache.commons.io.IOUtils;
 import org.reactivestreams.Publisher;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.MediaType;
 import org.springframework.http.codec.HttpMessageDecoder;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -19,11 +20,13 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 public class JsonDocumentDecoder implements HttpMessageDecoder<JsonDocument> {
@@ -36,7 +39,8 @@ public class JsonDocumentDecoder implements HttpMessageDecoder<JsonDocument> {
 
     @Override
     public boolean canDecode(ResolvableType elementType, MimeType mimeType) {
-        return elementType.isAssignableFrom(JsonDocument.class) && APPLICATION_JSON.isCompatibleWith(mimeType);
+        return elementType.isAssignableFrom(JsonDocument.class)
+                && (APPLICATION_JSON.isCompatibleWith(mimeType) || new MediaType("application", "*+json").isCompatibleWith(mimeType));
     }
 
     @Override
@@ -61,6 +65,6 @@ public class JsonDocumentDecoder implements HttpMessageDecoder<JsonDocument> {
 
     @Override
     public List<MimeType> getDecodableMimeTypes() {
-        return Collections.singletonList(APPLICATION_JSON);
+        return Arrays.asList(APPLICATION_JSON, HAL_JSON);
     }
 }

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
@@ -5,6 +5,7 @@
 
 package com.vmware.connectors.airwatch;
 
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.vmware.connectors.airwatch.config.ManagedApp;
 import com.vmware.connectors.airwatch.exceptions.GbAppMapException;
@@ -243,8 +244,8 @@ public class AirWatchController {
                 .uri(baseUri + "/catalog-portal/services/auth/eucTokens?deviceUdid={udid}&deviceType={deviceType}", udid, deviceType)
                 .cookie("HZN", hzn)
                 .retrieve()
-                .bodyToMono(JsonDocument.class)
-                .map(body -> body.read("$.eucToken"))
+                .bodyToMono(Map.class)
+                .map(body -> body.get("eucToken"))
                 .cast(String.class)
                 .doOnEach(Reactive.wrapForItem(token-> logger.trace("Install app. Got EUC token: {}", token)));
         }
@@ -272,7 +273,9 @@ public class AirWatchController {
                 .uri(gbSession.getBaseUrl() + "/catalog-portal/services/api/entitlements?q={appName}", appName)
                 .cookie("USER_CATALOG_CONTEXT", gbSession.getEucToken())
                 .retrieve()
-                .bodyToMono(JsonDocument.class)
+                .bodyToMono(String.class)
+                .map(s -> Configuration.defaultConfiguration().jsonProvider().parse(s))
+                .map(JsonDocument::new)
                 .map(document -> toGreenBoxApp(document, appName))
                 .doOnEach(Reactive.wrapForItem(gba -> logger.trace("Found GB app {} for {}", gba, appName)));
     }
@@ -300,8 +303,8 @@ public class AirWatchController {
                 .cookie("EUC_XSRF_TOKEN", gbSession.getCsrfToken())
                 .header("X-XSRF-TOKEN", gbSession.getCsrfToken())
                 .retrieve()
-                .bodyToMono(JsonDocument.class)
-                .map(body -> body.read("$.status"))
+                .bodyToMono(Map.class)
+                .map(body -> body.get("status"))
                 .cast(String.class)
                 .doOnEach(Reactive.wrapForItem(status ->
                         logger.trace("Install action status: {} for {}", status, gbApp)));

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
@@ -5,7 +5,6 @@
 
 package com.vmware.connectors.airwatch;
 
-import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.vmware.connectors.airwatch.config.ManagedApp;
 import com.vmware.connectors.airwatch.exceptions.GbAppMapException;
@@ -244,8 +243,8 @@ public class AirWatchController {
                 .uri(baseUri + "/catalog-portal/services/auth/eucTokens?deviceUdid={udid}&deviceType={deviceType}", udid, deviceType)
                 .cookie("HZN", hzn)
                 .retrieve()
-                .bodyToMono(Map.class)
-                .map(body -> body.get("eucToken"))
+                .bodyToMono(JsonDocument.class)
+                .map(body -> body.read("$.eucToken"))
                 .cast(String.class)
                 .doOnEach(Reactive.wrapForItem(token-> logger.trace("Install app. Got EUC token: {}", token)));
         }
@@ -273,9 +272,7 @@ public class AirWatchController {
                 .uri(gbSession.getBaseUrl() + "/catalog-portal/services/api/entitlements?q={appName}", appName)
                 .cookie("USER_CATALOG_CONTEXT", gbSession.getEucToken())
                 .retrieve()
-                .bodyToMono(String.class)
-                .map(s -> Configuration.defaultConfiguration().jsonProvider().parse(s))
-                .map(JsonDocument::new)
+                .bodyToMono(JsonDocument.class)
                 .map(document -> toGreenBoxApp(document, appName))
                 .doOnEach(Reactive.wrapForItem(gba -> logger.trace("Found GB app {} for {}", gba, appName)));
     }
@@ -303,8 +300,8 @@ public class AirWatchController {
                 .cookie("EUC_XSRF_TOKEN", gbSession.getCsrfToken())
                 .header("X-XSRF-TOKEN", gbSession.getCsrfToken())
                 .retrieve()
-                .bodyToMono(Map.class)
-                .map(body -> body.get("status"))
+                .bodyToMono(JsonDocument.class)
+                .map(body -> body.read("$.status"))
                 .cast(String.class)
                 .doOnEach(Reactive.wrapForItem(status ->
                         logger.trace("Install action status: {} for {}", status, gbApp)));

--- a/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
+++ b/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpMethod.*;
 import static org.springframework.http.HttpStatus.*;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON_UTF8;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.client.ExpectedCount.times;
@@ -148,14 +149,14 @@ class AirWatchControllerTest extends ControllerTestsBase {
         expectGBRequest(
                 "/catalog-portal/services/api/entitlements?q=Concur",
                 GET, gbCatalogContextCookie("euc123", null))
-                .andRespond(withSuccess().body(gbSearchApp).contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")));
+                .andRespond(withSuccess().body(gbSearchApp).contentType(HAL_JSON_UTF8));
 
         // Trigger install for "MDM-134-Native-Public".
         expectGBRequest(
                 "/catalog-portal/services/api/activate/MDM-134-Native-Public",
                 POST, gbCatalogContextCookie("euc123", "csrf123"))
                 .andExpect(MockRestRequestMatchers.header("X-XSRF-TOKEN", "csrf123"))
-                .andRespond(withSuccess().body(gbInstallApp).contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")));
+                .andRespond(withSuccess().body(gbInstallApp).contentType(HAL_JSON_UTF8));
 
         perform(post("/mdm/app/install").with(token(accessToken()))
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -262,7 +263,7 @@ class AirWatchControllerTest extends ControllerTestsBase {
         expectGBRequest(
                 "/catalog-portal/services/auth/eucTokens?deviceUdid=ABCD&deviceType=android",
                 POST, gbHZNCookie(accessToken()))
-                .andRespond(withStatus(CREATED).body(gbEucToken).contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")));
+                .andRespond(withStatus(CREATED).body(gbEucToken).contentType(HAL_JSON_UTF8));
 
         // CSRF token
         HttpHeaders csrfHeaders = new HttpHeaders();

--- a/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
+++ b/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.client.ResponseActions;
 import org.springframework.test.web.client.match.MockRestRequestMatchers;
@@ -147,14 +148,14 @@ class AirWatchControllerTest extends ControllerTestsBase {
         expectGBRequest(
                 "/catalog-portal/services/api/entitlements?q=Concur",
                 GET, gbCatalogContextCookie("euc123", null))
-                .andRespond(withSuccess().body(gbSearchApp).contentType(APPLICATION_JSON));
+                .andRespond(withSuccess().body(gbSearchApp).contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")));
 
         // Trigger install for "MDM-134-Native-Public".
         expectGBRequest(
                 "/catalog-portal/services/api/activate/MDM-134-Native-Public",
                 POST, gbCatalogContextCookie("euc123", "csrf123"))
                 .andExpect(MockRestRequestMatchers.header("X-XSRF-TOKEN", "csrf123"))
-                .andRespond(withSuccess().body(gbInstallApp).contentType(APPLICATION_JSON));
+                .andRespond(withSuccess().body(gbInstallApp).contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")));
 
         perform(post("/mdm/app/install").with(token(accessToken()))
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -261,7 +262,7 @@ class AirWatchControllerTest extends ControllerTestsBase {
         expectGBRequest(
                 "/catalog-portal/services/auth/eucTokens?deviceUdid=ABCD&deviceType=android",
                 POST, gbHZNCookie(accessToken()))
-                .andRespond(withStatus(CREATED).body(gbEucToken).contentType(APPLICATION_JSON));
+                .andRespond(withStatus(CREATED).body(gbEucToken).contentType(MediaType.valueOf("application/hal+json;charset=UTF-8")));
 
         // CSRF token
         HttpHeaders csrfHeaders = new HttpHeaders();


### PR DESCRIPTION
* Updates tests Content-Type from application/json to application/hal+json
* Changes greenbox calls to not blow up on hal+json

Signed-off-by: John Bard <jbard@vmware.com>