### PR TITLE
APF-988: Fix LoosePackageCoupling PMD warning

### DIFF
--- a/pmdrules.xml
+++ b/pmdrules.xml
@@ -31,6 +31,7 @@
     <rule ref="category/java/design.xml">
         <exclude name="DataClass"/>
         <exclude name="LawOfDemeter"/>
+        <exclude name="LoosePackageCoupling"/>
         <exclude name="DataClass"/>
         <exclude name="GodClass"/>
         <exclude name="ExcessiveImports"/>


### PR DESCRIPTION
The LoosePackageCoupling PMD rule requires packages and classes to be
specified.  This rule does not make sense to be on by default.  Since we aren't
using it (that would require identifying things we don't want accessed outside
of package hierarchies), I'm turning it off to get rid of the warnings.

Signed-off-by: John Bard <jbard@vmware.com>