### PR TITLE
APF-1045: heapdump on OutOfMemoryErrors

### DIFF
--- a/connectors/airwatch/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/airwatch/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/airwatch/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/airwatch/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='airwatch'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties,file:$etc_path/managed-apps.yml

--- a/connectors/airwatch/src/main/service/rhel/files/systemd/airwatch-connector.service
+++ b/connectors/airwatch/src/main/service/rhel/files/systemd/airwatch-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/airwatch/airwatch-connector.jar  --spring.config.additional-location=file:/opt/vmware/connectors/airwatch/application.properties,file:/etc/opt/vmware/connectors/airwatch/application.properties,file:/etc/opt/vmware/connectors/airwatch/managed-apps.yml
+ExecStart=/bin/bash /opt/vmware/connectors/airwatch/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/aws-cert/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/aws-cert/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/aws-cert/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/aws-cert/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='aws-cert'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/aws-cert/src/main/service/rhel/files/systemd/aws-cert-connector.service
+++ b/connectors/aws-cert/src/main/service/rhel/files/systemd/aws-cert-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/aws-cert/aws-cert-connector.jar --spring.config.additional-location=file:/opt/vmware/connectors/aws-cert/application.properties,file:/etc/opt/vmware/connectors/aws-cert/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/aws-cert/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/bitbucket-server/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/bitbucket-server/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/bitbucket-server/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/bitbucket-server/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='bitbucket-server'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/bitbucket-server/src/main/service/rhel/files/systemd/bitbucket-server-connector.service
+++ b/connectors/bitbucket-server/src/main/service/rhel/files/systemd/bitbucket-server-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/bitbucket-server/bitbucket-server-connector.jar --spring.config.additional-location=file:/opt/vmware/connectors/bitbucket-server/application.properties,file:/etc/opt/vmware/connectors/bitbucket-server/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/bitbucket-server/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/concur/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/concur/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/concur/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/concur/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='concur'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/concur/src/main/service/rhel/files/systemd/concur-connector.service
+++ b/connectors/concur/src/main/service/rhel/files/systemd/concur-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/concur/concur-connector.jar --spring.config.additional-location=file:/opt/vmware/connectors/concur/application.properties,file:/etc/opt/vmware/connectors/concur/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/concur/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/github-pr/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/github-pr/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/github-pr/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/github-pr/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='github-pr'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/github-pr/src/main/service/rhel/files/systemd/github-pr-connector.service
+++ b/connectors/github-pr/src/main/service/rhel/files/systemd/github-pr-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/github-pr/github-pr-connector.jar --spring.config.additional-location=file:/opt/vmware/connectors/github-pr/application.properties,file:/etc/opt/vmware/connectors/github-pr/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/github-pr/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/gitlab-pr/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/gitlab-pr/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/gitlab-pr/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/gitlab-pr/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='gitlab-pr'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/gitlab-pr/src/main/service/rhel/files/systemd/gitlab-pr-connector.service
+++ b/connectors/gitlab-pr/src/main/service/rhel/files/systemd/gitlab-pr-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/gitlab-pr/gitlab-pr-connector.jar --spring.config.additional-location=file:/opt/vmware/connectors/gitlab-pr/application.properties,file:/etc/opt/vmware/connectors/gitlab-pr/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/gitlab-pr/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/jira/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/jira/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/jira/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/jira/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='jira'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/jira/src/main/service/rhel/files/systemd/jira-connector.service
+++ b/connectors/jira/src/main/service/rhel/files/systemd/jira-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/jira/jira-connector.jar  --spring.config.additional-location=file:/opt/vmware/connectors/jira/application.properties,file:/etc/opt/vmware/connectors/jira/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/jira/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/salesforce/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/salesforce/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/salesforce/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/salesforce/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='salesforce'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/salesforce/src/main/service/rhel/files/systemd/salesforce-connector.service
+++ b/connectors/salesforce/src/main/service/rhel/files/systemd/salesforce-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/salesforce/salesforce-connector.jar --spring.config.additional-location=file:/opt/vmware/connectors/salesforce/application.properties,file:/etc/opt/vmware/connectors/salesforce/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/salesforce/start.sh
 Restart=on-abort
 
 [Install]

--- a/connectors/servicenow/src/main/service/rhel/files/default-conf/jvm.conf
+++ b/connectors/servicenow/src/main/service/rhel/files/default-conf/jvm.conf
@@ -1,0 +1,3 @@
+export JVM_OPTS=""
+export JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+export JVM_OPTS="$JVM_OPTS -XX:+UnlockExperimentalVMOptions -XX:MaxRAMFraction=2"

--- a/connectors/servicenow/src/main/service/rhel/files/default-conf/start.sh
+++ b/connectors/servicenow/src/main/service/rhel/files/default-conf/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+connector_name='servicenow'
+install_path="/opt/vmware/connectors/$connector_name"
+etc_path="/etc/opt/vmware/connectors/$connector_name"
+
+source $install_path/jvm.conf
+
+/usr/bin/java $JVM_OPTS \
+    -jar $install_path/${connector_name}-connector.jar \
+    --spring.config.additional-location=file:$install_path/application.properties,file:$etc_path/application.properties

--- a/connectors/servicenow/src/main/service/rhel/files/systemd/servicenow-connector.service
+++ b/connectors/servicenow/src/main/service/rhel/files/systemd/servicenow-connector.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=roswell
-ExecStart=/usr/bin/java -jar /opt/vmware/connectors/servicenow/servicenow-connector.jar --spring.config.additional-location=file:/opt/vmware/connectors/servicenow/application.properties,file:/etc/opt/vmware/connectors/servicenow/application.properties
+ExecStart=/bin/bash /opt/vmware/connectors/servicenow/start.sh
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
* Moves systemd ExecStart command to a script for easier maintenance
* Adds options to dump heap on OutOfMemoryError
* Updates memory options to be more reasonable than JVM defaults

Signed-off-by: John Bard <jbard@vmware.com>