### PR TITLE
Apf 1014 avoid npe for unassigned mdm apps

### DIFF
--- a/connectors/airwatch/README.md
+++ b/connectors/airwatch/README.md
@@ -4,6 +4,7 @@ The AirWatch connector presents cards inviting the user to install apps that are
 
 Informal application keywords are resolved to bundle IDs using mappings specified in `/etc/opt/vmware/connectors/airwatch/managed-apps.yml`. For example:
 ```
+airwatch:
   apps:
     - app: Coupa
       android:

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
@@ -286,10 +286,17 @@ public class AirWatchController {
         int RIGHT_APP_COUNT = 1;
 
         JSONArray jsonArray = document.read("$._embedded.entitlements");
+
+        if (jsonArray == null) {
+            throw new GbAppMapException(
+                    "vIDM catalog doesn't contain " + appName);
+        }
+
         if (jsonArray.size() != RIGHT_APP_COUNT) {
             throw new GbAppMapException(
                     "Unable to map " + appName + " to a single GreenBox app");
         }
+
         return new GreenBoxApp(
                 document.read("$._embedded.entitlements[0].name"),
                 document.read("$._embedded.entitlements[0]._links.install.href"));

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/AirWatchController.java
@@ -283,7 +283,6 @@ public class AirWatchController {
     }
 
     private GreenBoxApp toGreenBoxApp(JsonDocument document, String appName) {
-        int RIGHT_APP_COUNT = 1;
 
         JSONArray jsonArray = document.read("$._embedded.entitlements");
 
@@ -292,6 +291,7 @@ public class AirWatchController {
                     "vIDM catalog doesn't contain " + appName);
         }
 
+        int RIGHT_APP_COUNT = 1;
         if (jsonArray.size() != RIGHT_APP_COUNT) {
             throw new GbAppMapException(
                     "Unable to map " + appName + " to a single GreenBox app");

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/AppConfiguration.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/AppConfiguration.java
@@ -23,11 +23,11 @@ public class AppConfiguration {
 
     private List<String> keywords;
 
-    public String getApplication() {
+    public String getApp() {
         return app;
     }
 
-    public void setApplication(String application) {
+    public void setApp(String application) {
         this.app = application;
     }
 

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/service/AppConfigService.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/service/AppConfigService.java
@@ -8,6 +8,8 @@ package com.vmware.connectors.airwatch.service;
 import com.vmware.connectors.airwatch.config.AppConfiguration;
 import com.vmware.connectors.airwatch.config.AppConfigurations;
 import com.vmware.connectors.airwatch.config.ManagedApp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -15,6 +17,8 @@ import java.util.Optional;
  * Created by harshas on 9/19/17.
  */
 public class AppConfigService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AppConfigService.class);
 
     private final AppConfigurations appConfigurations;
 
@@ -25,6 +29,12 @@ public class AppConfigService {
     public Optional<ManagedApp> findManagedApp(String keyword, String platform) {
         for (AppConfiguration appConfiguration : appConfigurations.getApps()) {
             ManagedApp app = appConfiguration.getApp(platform);
+
+            if (app == null) {
+                logger.warn("{} app is not configured for {} platform.", appConfiguration.getApp(), platform);
+                continue;
+            }
+
             // If the keyword matches to the app's name or its configured keywords.
             if (app.getName().equalsIgnoreCase(keyword) ||
                     appConfiguration.getKeywords().stream().anyMatch(keyword::equalsIgnoreCase)) {

--- a/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
+++ b/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
@@ -145,7 +145,7 @@ class AirWatchControllerTest extends ControllerTestsBase {
     @Test
     void testInstallAction() throws Exception {
 
-        expectGBSessionRequests();
+        expectGBSessionRequests("android");
 
         // Search for app "Concur"
         expectGBRequest(
@@ -177,7 +177,7 @@ class AirWatchControllerTest extends ControllerTestsBase {
             "unassignedMdmApp, searchAppNotFound.json"})
     void testInstallActionBadRequest(String appName, String gbResponseFile) throws Exception {
 
-        expectGBSessionRequests();
+        expectGBSessionRequests("Apple");
 
         expectGBRequest(
                 "/catalog-portal/services/api/entitlements?q=" + appName,
@@ -190,7 +190,7 @@ class AirWatchControllerTest extends ControllerTestsBase {
                 .header("x-airwatch-base-url", AIRWATCH_BASE_URL)
                 .param("app_name", appName)
                 .param("udid", "ABCD")
-                .param("platform", "android"))
+                .param("platform", "ios"))
                 .andExpect(status().isBadRequest());
 
         mockBackend.verify();
@@ -285,10 +285,10 @@ class AirWatchControllerTest extends ControllerTestsBase {
                 .andExpect(MockRestRequestMatchers.header(AUTHORIZATION, "Bearer " + accessToken()));
     }
 
-    private void expectGBSessionRequests() {
+    private void expectGBSessionRequests(String deviceType) {
         // eucToken
         expectGBRequest(
-                "/catalog-portal/services/auth/eucTokens?deviceUdid=ABCD&deviceType=android",
+                "/catalog-portal/services/auth/eucTokens?deviceUdid=ABCD&deviceType=" + deviceType,
                 POST, gbHZNCookie(accessToken()))
                 .andRespond(withStatus(CREATED).body(gbEucToken).contentType(HAL_JSON_UTF8));
 

--- a/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
+++ b/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
@@ -142,6 +142,20 @@ class AirWatchControllerTest extends ControllerTestsBase {
         testRequestCards(requestFile, responseFile, acceptLanguage);
     }
 
+    /*
+     * Boxer - Not installed.
+     * Concur - Installed
+     * customer support - Zendesk is not configured for iOS.
+     */
+    @Test
+    void testRequestCardsSuccessiOS() throws Exception {
+        expectAWRequest("/deviceservices/AppInstallationStatus?Udid=ABCD&BundleId=com.air-watch.boxer")
+                .andRespond(withSuccess(awAppNotInstalled, APPLICATION_JSON));
+        expectAWRequest("/deviceservices/AppInstallationStatus?Udid=ABCD&BundleId=com.concur.concurmobile")
+                .andRespond(withSuccess(awAppInstalled, APPLICATION_JSON));
+        testRequestCards("requestiOS.json", "successiOS.json", null);
+    }
+
     @Test
     void testInstallAction() throws Exception {
 

--- a/connectors/airwatch/src/test/resources/app.properties
+++ b/connectors/airwatch/src/test/resources/app.properties
@@ -23,12 +23,12 @@ airwatch.apps[2].keywords[0]=poison
 # Configuration mistake. Correct app name for android is "VMware Browser".
 # There are Firefox and VMware browsers in vIDM catalog.
 airwatch.apps[3].app=Browser
-airwatch.apps[3].android.name=Browser
-airwatch.apps[3].android.id=com.air-watch.secure.browser
+airwatch.apps[3].ios.name=Browser
+airwatch.apps[3].ios.id=com.air-watch.secure.browser
 airwatch.apps[3].keywords[0]=browser
 
 # App added as MDM, but not yet assigned to the user.
 airwatch.apps[4].app=Some MDM app
-airwatch.apps[4].android.name=unassignedMdmApp
-airwatch.apps[4].android.id=some.mdm.app
+airwatch.apps[4].ios.name=unassignedMdmApp
+airwatch.apps[4].ios.id=some.mdm.app
 airwatch.apps[4].keywords[0]=unassignedMdmApp

--- a/connectors/airwatch/src/test/resources/app.properties
+++ b/connectors/airwatch/src/test/resources/app.properties
@@ -19,3 +19,16 @@ airwatch.apps[2].app=Poison
 airwatch.apps[2].android.name=Poison pill
 airwatch.apps[2].android.id=com.poison.pill
 airwatch.apps[2].keywords[0]=poison
+
+# Configuration mistake. Correct app name for android is "VMware Browser".
+# There are Firefox and VMware browsers in vIDM catalog.
+airwatch.apps[3].app=Browser
+airwatch.apps[3].android.name=Browser
+airwatch.apps[3].android.id=com.air-watch.secure.browser
+airwatch.apps[3].keywords[0]=browser
+
+# App added as MDM, but not yet assigned to the user.
+airwatch.apps[4].app=Some MDM app
+airwatch.apps[4].android.name=unassignedMdmApp
+airwatch.apps[4].android.id=some.mdm.app
+airwatch.apps[4].keywords[0]=unassignedMdmApp

--- a/connectors/airwatch/src/test/resources/app.properties
+++ b/connectors/airwatch/src/test/resources/app.properties
@@ -32,3 +32,9 @@ airwatch.apps[4].app=Some MDM app
 airwatch.apps[4].ios.name=unassignedMdmApp
 airwatch.apps[4].ios.id=some.mdm.app
 airwatch.apps[4].keywords[0]=unassignedMdmApp
+
+# Zendesk is configured only for android.
+airwatch.apps[5].app=Zendesk
+airwatch.apps[5].android.name=Zendesk Support
+airwatch.apps[5].android.id=com.zendesk.android
+airwatch.apps[5].keywords[0]=customer support

--- a/connectors/airwatch/src/test/resources/connector/requests/request.json
+++ b/connectors/airwatch/src/test/resources/connector/requests/request.json
@@ -2,6 +2,6 @@
   "tokens": {
     "udid": ["ABCD"],
     "platform": ["android"],
-    "app_keywords": ["Boxer", "Concur"]
+    "app_keywords": ["Boxer", "Concur", "browser"]
   }
 }

--- a/connectors/airwatch/src/test/resources/connector/requests/requestiOS.json
+++ b/connectors/airwatch/src/test/resources/connector/requests/requestiOS.json
@@ -1,0 +1,7 @@
+{
+  "tokens": {
+    "udid": ["ABCD"],
+    "platform": ["iOS"],
+    "app_keywords": ["Boxer", "Concur", "customer support"]
+  }
+}

--- a/connectors/airwatch/src/test/resources/connector/responses/metadata.json
+++ b/connectors/airwatch/src/test/resources/connector/responses/metadata.json
@@ -9,7 +9,7 @@
     },
     "app_keywords": {
       "capture_group": 1,
-      "regex": "((?i)\\bboxer\\b|\\bemail app\\b|\\bconcur\\b|\\bpoison\\b)"
+      "regex": "((?i)\\bboxer\\b|\\bemail app\\b|\\bconcur\\b|\\bpoison\\b|\\bbrowser\\b|\\bunassignedMdmApp\\b)"
     }
   }
 }

--- a/connectors/airwatch/src/test/resources/connector/responses/metadata.json
+++ b/connectors/airwatch/src/test/resources/connector/responses/metadata.json
@@ -9,7 +9,7 @@
     },
     "app_keywords": {
       "capture_group": 1,
-      "regex": "((?i)\\bboxer\\b|\\bemail app\\b|\\bconcur\\b|\\bpoison\\b|\\bbrowser\\b|\\bunassignedMdmApp\\b)"
+      "regex": "((?i)\\bboxer\\b|\\bemail app\\b|\\bconcur\\b|\\bpoison\\b|\\bbrowser\\b|\\bunassignedMdmApp\\b|\\bcustomer support\\b)"
     }
   }
 }

--- a/connectors/airwatch/src/test/resources/connector/responses/successiOS.json
+++ b/connectors/airwatch/src/test/resources/connector/responses/successiOS.json
@@ -1,0 +1,36 @@
+{
+  "cards": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "name": "AirWatch",
+      "creation_date": "1970-01-01T00:00:00Z",
+      "template": {
+        "href": "https://hero/connectors/airwatch/templates/generic.hbs"
+      },
+      "header": {
+        "title": "[AirWatch] vmware boxer"
+      },
+      "body": {
+        "description": "Please install this application for better interaction with the resource."
+      },
+      "actions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "label": "Install",
+          "url": {
+            "href": "https://hero/connectors/airwatch/mdm/app/install"
+          },
+          "type": "POST",
+          "action_key": "DIRECT",
+          "request": {
+            "app_name": "vmware boxer",
+            "udid": "ABCD",
+            "platform": "iOS"
+          },
+          "user_input": [],
+          "completed_label":"Installed"
+        }
+      ]
+    }
+  ]
+}

--- a/connectors/airwatch/src/test/resources/greenbox/responses/searchAppMultipleFound.json
+++ b/connectors/airwatch/src/test/resources/greenbox/responses/searchAppMultipleFound.json
@@ -1,0 +1,89 @@
+{
+  "allProfilesLoaded": false,
+  "deviceInfo": {
+    "deviceStatus": "MDM_DEVICE_FULLY_ENROLLED"
+  },
+  "_embedded": {
+    "entitlements": [
+      {
+        "appId": "MDM-149-Native-Public",
+        "subType": "PUBLIC",
+        "version": "",
+        "thinapp": false,
+        "visible": true,
+        "perDeviceActivationRequired": false,
+        "thinappPackage": false,
+        "approvalRequired": false,
+        "favorite": false,
+        "optionalAppInfo": {
+          "usePerAppPassword": false
+        },
+        "price": null,
+        "launchUrl": "",
+        "mdmManagedAutoDeployed": false,
+        "installStatus": "NOT_ACTIVATED",
+        "installMessage": "You will receive a push notification to continue with installation.",
+        "packageFamilyName": "989804926",
+        "mgmtRequired": false,
+        "useAirwatchBrowser": false,
+        "name": "Firefox Web Browser",
+        "type": "NATIVE",
+        "size": 0,
+        "_links": {
+          "icon": {
+            "href": "https://HeroCardAdmin1.ssdevrd.com/Catalog/publicblob/515e3992-08e1-47d9-b8a6-288600c49ba5/BlobHandler.pblob"
+          },
+          "install": {
+            "href": "https://herocard.vmwareidentity.com:443/catalog-portal/services/api/activate/MDM-149-Native-Public"
+          },
+          "appDetails": {
+            "href": "https://herocard.vmwareidentity.com:443/catalog-portal/services/api/apps/MDM-149-Native-Public"
+          }
+        }
+      },
+      {
+        "appId": "MDM-150-Native-Public",
+        "subType": "PUBLIC",
+        "version": "",
+        "thinapp": false,
+        "visible": true,
+        "perDeviceActivationRequired": false,
+        "thinappPackage": false,
+        "approvalRequired": false,
+        "favorite": false,
+        "optionalAppInfo": {
+          "usePerAppPassword": false
+        },
+        "price": null,
+        "launchUrl": "",
+        "mdmManagedAutoDeployed": false,
+        "installStatus": "NOT_ACTIVATED",
+        "installMessage": "You will receive a push notification to continue with installation.",
+        "packageFamilyName": "525891468",
+        "mgmtRequired": false,
+        "useAirwatchBrowser": false,
+        "name": "VMware Browser",
+        "type": "NATIVE",
+        "size": 0,
+        "_links": {
+          "icon": {
+            "href": "https://HeroCardAdmin1.ssdevrd.com/Catalog/publicblob/c5c7b4f5-8220-47a2-90ec-490a2d8e11b6/BlobHandler.pblob"
+          },
+          "install": {
+            "href": "https://herocard.vmwareidentity.com:443/catalog-portal/services/api/activate/MDM-150-Native-Public"
+          },
+          "appDetails": {
+            "href": "https://herocard.vmwareidentity.com:443/catalog-portal/services/api/apps/MDM-150-Native-Public"
+          }
+        }
+      }
+    ]
+  },
+  "userIdMismatch": false,
+  "allEntitlementsLoaded": true,
+  "_links": {
+    "self": {
+      "href": "https://herocard.vmwareidentity.com:443/catalog-portal/services/api/entitlements?q=Browser&category=&appType="
+    }
+  }
+}

--- a/connectors/airwatch/src/test/resources/greenbox/responses/searchAppNotFound.json
+++ b/connectors/airwatch/src/test/resources/greenbox/responses/searchAppNotFound.json
@@ -1,0 +1,13 @@
+{
+  "allProfilesLoaded": false,
+  "deviceInfo": {
+    "deviceStatus": "MDM_DEVICE_FULLY_ENROLLED"
+  },
+  "allEntitlementsLoaded": true,
+  "userIdMismatch": false,
+  "_links": {
+    "self": {
+      "href": "https://herocard.vmwareidentity.com:443/catalog-portal/services/api/entitlements?q=unassignedMdmApp&category=&appType="
+    }
+  }
+}


### PR DESCRIPTION
- NPE 1 : 
If app install card-action is performed for an app, which is added as MDM but not yet assigned.
Since the assignment is not done, this app will be missing in vIDM catalog.
( DS says the app's install status is `false` which leads to AirWatch card generation. )

- NPE 2 : 
There can be a missing configuration for any platform in `managed-apps.yml` file. Card request for this platform is now just skipped silently. 

