### PR TITLE
APF-1137 Use Phaser to make tests more deterministic

### DIFF
--- a/common/connectors-test/src/main/java/com/vmware/connectors/test/ControllerTestsBase.java
+++ b/common/connectors-test/src/main/java/com/vmware/connectors/test/ControllerTestsBase.java
@@ -15,23 +15,38 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientCodecCustomizer;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -183,6 +198,49 @@ public class ControllerTestsBase {
             }
 
             return allMatches;
+        }
+    }
+
+    @TestConfiguration
+    static class ControllerTestConfiguration {
+
+        @Bean
+        public WebClient.Builder webClientBuilder(WebClientCodecCustomizer codecCustomizer) {
+            WebClient.Builder builder = WebClient.builder();
+            codecCustomizer.customize(builder);
+            return builder.clientConnector(new PhaserClientHttpConnector());
+         }
+    }
+
+    private static class PhaserClientHttpConnector implements ClientHttpConnector {
+        private final Scheduler scheduler = Schedulers.elastic();
+        private final ReactorClientHttpConnector reactorClientHttpConnector = new ReactorClientHttpConnector();
+
+        // Use a phaser to ensure we don't emit a response until all parallel calls have received responses.
+        // This prevents non-deterministic behavior, where OkHttp /might/ return an error status before a
+        // second request has been sent. Since the failure can cancel the subscription,
+        // verifying that the second call happened will fail.
+        private final Phaser phaser = new Phaser() {
+            @Override
+            protected boolean onAdvance(int phase, int registeredParties) {
+                return false;
+            }
+        };
+
+        @Override
+        public Mono<ClientHttpResponse> connect(HttpMethod method, URI uri, Function<? super ClientHttpRequest, Mono<Void>> requestCallback) {
+            int phase = phaser.getPhase();
+            phaser.register();
+            return reactorClientHttpConnector.connect(method, uri, requestCallback)
+                    .doOnSuccessOrError((response, throwable) -> phaser.arriveAndDeregister())
+                    .delayUntil(response -> awaitAdvance(phase));
+        }
+
+        private Mono<?> awaitAdvance(int phase) {
+            // Subscribe on an elastic pool because awaitAdvanceInterruptibly blocks and we don't want to
+            // starve the finite reactor pool.
+            return Mono.fromCallable(() -> phaser.awaitAdvanceInterruptibly(phase, 4, TimeUnit.SECONDS))
+                    .subscribeOn(scheduler);
         }
     }
 

--- a/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
+++ b/connectors/airwatch/src/test/java/com/vmware/connectors/airwatch/AirWatchControllerTest.java
@@ -24,7 +24,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.support.TestPropertySourceUtils;
-import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.ResponseActions;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -45,7 +44,7 @@ import static org.springframework.http.HttpMethod.*;
 import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.client.ExpectedCount.*;
+import static org.springframework.test.web.client.ExpectedCount.times;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
@@ -261,7 +260,7 @@ class AirWatchControllerTest extends ControllerTestsBase {
      */
     @Test
     void testRequestCardsForbidden() throws Exception {
-        mockBackend.expect(times(1), requestTo(any(String.class)))
+        mockBackend.expect(times(2), requestTo(any(String.class)))
                 .andExpect(header(AUTHORIZATION, "Bearer " + accessToken()))
                 .andExpect(method(GET))
                 .andRespond(withStatus(FORBIDDEN).body(awUserForbidden));
@@ -274,7 +273,7 @@ class AirWatchControllerTest extends ControllerTestsBase {
     void testRequestCardsOneServerError() throws Exception {
         expectAWRequest("/deviceservices/AppInstallationStatus?Udid=ABCD&BundleId=com.poison.pill")
                 .andRespond(withServerError());
-        expectAWRequest(between(0, 1), "/deviceservices/AppInstallationStatus?Udid=ABCD&BundleId=com.android.boxer")
+        expectAWRequest("/deviceservices/AppInstallationStatus?Udid=ABCD&BundleId=com.android.boxer")
                 .andRespond(withSuccess(awAppNotInstalled, APPLICATION_JSON));
         requestCards("oneServerError.json")
                 .exchange()
@@ -328,14 +327,10 @@ class AirWatchControllerTest extends ControllerTestsBase {
                 .syncBody(fromFile("/connector/requests/" + requestfile));
     }
 
-    private ResponseActions expectAWRequest(ExpectedCount count, String uri) {
-        return mockBackend.expect(count, requestTo(uri))
+    private ResponseActions expectAWRequest(String uri) {
+        return mockBackend.expect(requestTo(uri))
                 .andExpect(method(GET))
                 .andExpect(header(AUTHORIZATION, "Bearer " + accessToken()));
-    }
-
-    private ResponseActions expectAWRequest(String uri) {
-        return expectAWRequest(once(), uri);
     }
 
     private void expectGBSessionRequests(String deviceType) {

--- a/connectors/bitbucket-server/src/main/java/com/vmware/connectors/bitbucket/server/BitbucketServerController.java
+++ b/connectors/bitbucket-server/src/main/java/com/vmware/connectors/bitbucket/server/BitbucketServerController.java
@@ -15,7 +15,6 @@ import com.vmware.connectors.common.payloads.response.*;
 import com.vmware.connectors.common.utils.CardTextAccessor;
 import com.vmware.connectors.common.utils.CommonUtils;
 import com.vmware.connectors.common.utils.Reactive;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -238,9 +237,9 @@ public class BitbucketServerController {
         final Mono<JsonDocument> bitBucketServerResponse = getPullRequestInfo(authHeader, pullRequest, baseUrl);
         final Mono<List<String>> comments = getComments(baseUrl, authHeader, pullRequest);
 
-        return Mono.zip(bitBucketServerResponse, comments, Pair::of)
+        return Mono.zip(bitBucketServerResponse, comments)
                 .onErrorResume(Reactive::skipOnNotFound)
-                .map(pair -> convertResponseIntoCard(pair.getLeft(), pullRequest, routingPrefix, pair.getRight(), locale, request));
+                .map(pair -> convertResponseIntoCard(pair.getT1(), pullRequest, routingPrefix, pair.getT2(), locale, request));
     }
 
     private Mono<JsonDocument> getPullRequestInfo(final String authHeader,

--- a/connectors/bitbucket-server/src/test/java/com/vmware/connectors/bitbucket/server/BitbucketServerControllerTest.java
+++ b/connectors/bitbucket-server/src/test/java/com/vmware/connectors/bitbucket/server/BitbucketServerControllerTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.ResponseActions;
 import org.springframework.test.web.client.match.MockRestRequestMatchers;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -38,8 +37,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpMethod.*;
 import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.client.ExpectedCount.between;
-import static org.springframework.test.web.client.ExpectedCount.once;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
@@ -142,11 +139,11 @@ class BitbucketServerControllerTest extends ControllerTestsBase {
 
         expect(pr236Url).andRespond(withSuccess(pr236, APPLICATION_JSON));
         expect(pr246Url).andRespond(withSuccess(pr246, APPLICATION_JSON));
-        expect(between(0, 1), notFoundUrl).andRespond(withStatus(HttpStatus.NOT_FOUND));
+        expect(notFoundUrl).andRespond(withStatus(HttpStatus.NOT_FOUND));
 
         expect(pr236Url + "/activities").andRespond(withSuccess(pr236Activities, APPLICATION_JSON));
         expect(pr246Url + "/activities").andRespond(withSuccess(pr246Activities, APPLICATION_JSON));
-        expect(between(0, 1), notFoundUrl + "/activities").andRespond(withStatus(HttpStatus.NOT_FOUND));
+        expect(notFoundUrl + "/activities").andRespond(withStatus(HttpStatus.NOT_FOUND));
     }
 
     @ParameterizedTest(name = "{index} ==> ''{0}''")
@@ -282,11 +279,7 @@ class BitbucketServerControllerTest extends ControllerTestsBase {
     }
 
     private ResponseActions expect(final String url) {
-        return expect(once(), url);
-    }
-
-    private ResponseActions expect(ExpectedCount count, final String url) {
-        return mockBackend.expect(count, requestTo(url))
+        return mockBackend.expect(requestTo(url))
                 .andExpect(method(GET))
                 .andExpect(MockRestRequestMatchers.header(AUTHORIZATION, "Basic bitbucket-token"));
     }

--- a/connectors/jira/src/test/java/com/vmware/connectors/jira/JiraControllerTest.java
+++ b/connectors/jira/src/test/java/com/vmware/connectors/jira/JiraControllerTest.java
@@ -182,7 +182,7 @@ class JiraControllerTest extends ControllerTestsBase {
 
     @Test
     void testRequestCardsNotAuthorized() throws Exception {
-        mockBackend.expect(times(1), requestTo(any(String.class)))
+        mockBackend.expect(times(2), requestTo(any(String.class)))
                 .andExpect(MockRestRequestMatchers.header(AUTHORIZATION, "Bearer bogus"))
                 .andExpect(method(GET))
                 .andRespond(withUnauthorizedRequest());
@@ -215,6 +215,7 @@ class JiraControllerTest extends ControllerTestsBase {
     @Test
     void testRequestCardsOneServerError() throws Exception {
         expect("POISON-PILL").andRespond(withServerError());
+        expect("APF-27").andRespond(withSuccess(apf27, APPLICATION_JSON));
         requestCards("abc", "oneServerError.json")
                 .exchange()
                 .expectStatus().is5xxServerError()


### PR DESCRIPTION
This change will ensure that no http response will be emitted
until all parallel calls have returned responses or failed. This prevents the problem
where call 1 causes an exception before call 2 is made.
This is fine (in fact, desirable) in production, but not ideal for tests,
where we want to be able to "expect" calls precisely.
Also, this will make the tests behave more like production, where
we're much more likely to not see any responses before all parallel requests
have been sent. It's the very fast response times from the OkHttp mock
server that cause the problem.