### PR TITLE
APF-1170 Validations for managed-app configurations

### DIFF
--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/ConnConfiguration.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/ConnConfiguration.java
@@ -6,8 +6,11 @@
 package com.vmware.connectors.airwatch;
 
 import com.vmware.connectors.airwatch.config.AppConfigurations;
+import com.vmware.connectors.airwatch.exceptions.AppConfigException;
 import com.vmware.connectors.airwatch.service.AppConfigService;
 import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,9 +18,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 
+import javax.validation.Validator;
+import javax.validation.Validation;
+import javax.validation.ConstraintViolation;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
@@ -27,6 +34,8 @@ import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
  */
 @Configuration
 public class ConnConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConnConfiguration.class);
 
     private final AppConfigurations appConfigurations;
 
@@ -38,6 +47,16 @@ public class ConnConfiguration {
     public ConnConfiguration(AppConfigurations appConfigurations,
                              Environment environment,
                              @Value("classpath:static/discovery/metadata.json") Resource metadataHalResource) {
+
+        // Validate managed-apps.yml configurations.
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Set<ConstraintViolation<AppConfigurations>> violations = validator.validate(appConfigurations);
+        violations
+                .forEach(v -> logger.error("{} Check {} in managed-apps configuration.", v.getMessage(), v.getPropertyPath().toString()));
+        if (!violations.isEmpty()) {
+            throw new AppConfigException("Invalid configurations for managed-apps.");
+        }
+
         this.appConfigurations = appConfigurations;
         this.environment = environment;
         this.metadataHalResource = metadataHalResource;
@@ -65,7 +84,11 @@ public class ConnConfiguration {
 
     @Bean
     public URI gbBaseUrl() {
-        String gbUrl = environment.getProperty("greenbox.url");
-        return fromHttpUrl(gbUrl).build().toUri();
+        try {
+            return fromHttpUrl(environment.getProperty("greenbox.url")).build().toUri();
+        } catch (IllegalArgumentException ex) {
+            logger.error("Greenbox URL config is invalid. ", ex);
+            return null;
+        }
     }
 }

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/ConnConfiguration.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/ConnConfiguration.java
@@ -6,7 +6,7 @@
 package com.vmware.connectors.airwatch;
 
 import com.vmware.connectors.airwatch.config.AppConfigurations;
-import com.vmware.connectors.airwatch.exceptions.AppConfigException;
+import com.vmware.connectors.airwatch.exceptions.ConfigException;
 import com.vmware.connectors.airwatch.service.AppConfigService;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -54,7 +54,7 @@ public class ConnConfiguration {
         violations
                 .forEach(v -> logger.error("{} Check {} in managed-apps configuration.", v.getMessage(), v.getPropertyPath().toString()));
         if (!violations.isEmpty()) {
-            throw new AppConfigException("Invalid configurations for managed-apps.");
+            throw new ConfigException("Invalid configurations for managed-apps.");
         }
 
         this.appConfigurations = appConfigurations;
@@ -88,7 +88,7 @@ public class ConnConfiguration {
             return fromHttpUrl(environment.getProperty("greenbox.url")).build().toUri();
         } catch (IllegalArgumentException ex) {
             logger.error("Greenbox URL config is invalid. ", ex);
-            return null;
+            throw new ConfigException("Greenbox URL config is invalid.", ex);
         }
     }
 }

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/AppConfiguration.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/AppConfiguration.java
@@ -7,6 +7,7 @@ package com.vmware.connectors.airwatch.config;
 
 import com.vmware.connectors.airwatch.exceptions.UnsupportedPlatform;
 
+import javax.validation.Valid;
 import java.util.List;
 
 /**
@@ -17,8 +18,10 @@ public class AppConfiguration {
 
     private String app;
 
+    @Valid
     private ManagedApp android;
 
+    @Valid
     private ManagedApp ios;
 
     private List<String> keywords;

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/AppConfigurations.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/AppConfigurations.java
@@ -9,15 +9,19 @@ package com.vmware.connectors.airwatch.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 /**
  * Created by harshas on 01/31/18.
  */
-@ConfigurationProperties(prefix = "airwatch")
+@ConfigurationProperties(prefix = "airwatch", ignoreInvalidFields = true)
 @Component
 public class AppConfigurations {
 
+    @Valid
+    @NotNull(message = "Please provide details of all managed apps via a config YML file.")
     private List<AppConfiguration> apps;
 
     public List<AppConfiguration> getApps() {

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/ManagedApp.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/config/ManagedApp.java
@@ -8,14 +8,18 @@ package com.vmware.connectors.airwatch.config;
 import org.pojomatic.Pojomatic;
 import org.pojomatic.annotations.AutoProperty;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Created by harshas on 01/31/18.
  */
 @AutoProperty
 public class ManagedApp {
 
+    @NotNull(message = "App name should be provided for the platform.")
     private String name;
 
+    @NotNull(message = "App id should be provided for the platform.")
     private String id;
 
     public String getName() {

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/exceptions/AppConfigException.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/exceptions/AppConfigException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2018 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package com.vmware.connectors.airwatch.exceptions;
+
+/**
+ * Created by harshas on 05/16/18.
+ */
+public class AppConfigException extends RuntimeException {
+
+    public AppConfigException(String message) {
+        super(message);
+    }
+}

--- a/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/exceptions/ConfigException.java
+++ b/connectors/airwatch/src/main/java/com/vmware/connectors/airwatch/exceptions/ConfigException.java
@@ -8,9 +8,13 @@ package com.vmware.connectors.airwatch.exceptions;
 /**
  * Created by harshas on 05/16/18.
  */
-public class AppConfigException extends RuntimeException {
+public class ConfigException extends RuntimeException {
 
-    public AppConfigException(String message) {
+    public ConfigException(String message) {
         super(message);
+    }
+
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
     }
 }


### PR DESCRIPTION
- Check if managed-apps.yml configuration is missing.
- greenbox.url
- App name or Id may be missing for apps on each platform.

<img width="418" alt="managed-apps" src="https://user-images.githubusercontent.com/10612833/40138415-39d08d1a-596a-11e8-84f8-119724c42e3e.png">

[error-logs.txt](https://github.com/vmware/connectors-workspace-one/files/2010479/error-logs.txt)
