### PR TITLE
APF-1121 Release resources in JsonDocumentDecoder

### DIFF
--- a/common/core/src/main/java/com/vmware/connectors/common/json/JsonDocumentDecoder.java
+++ b/common/core/src/main/java/com/vmware/connectors/common/json/JsonDocumentDecoder.java
@@ -20,12 +20,13 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.hateoas.MediaTypes.HAL_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
@@ -51,13 +52,7 @@ public class JsonDocumentDecoder implements HttpMessageDecoder<JsonDocument> {
     @Override
     public Mono<JsonDocument> decodeToMono(Publisher<DataBuffer> inputStream, ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
         return Flux.from(inputStream)
-                .flatMap(buffer -> {
-                    try {
-                        return Flux.just(IOUtils.toString(buffer.asInputStream(), UTF_8));
-                    } catch (IOException e) {
-                        return Flux.error(e);
-                    }
-                })
+                .flatMap(buffer -> toString(buffer, mimeType.getCharset()))
                 .collect(StringBuilder::new, StringBuilder::append)
                 .map(StringBuilder::toString)
                 .map(message -> new JsonDocument(jsonProvider.parse(message)));
@@ -66,5 +61,13 @@ public class JsonDocumentDecoder implements HttpMessageDecoder<JsonDocument> {
     @Override
     public List<MimeType> getDecodableMimeTypes() {
         return Arrays.asList(APPLICATION_JSON, HAL_JSON);
+    }
+
+    private static Flux<String> toString(DataBuffer buffer, Charset charset) {
+        try (InputStream is = buffer.asInputStream(true)) {
+            return Flux.just(IOUtils.toString(is, charset));
+        } catch (IOException e) {
+            return Flux.error(e);
+        }
     }
 }


### PR DESCRIPTION
This fixes a memory leak.

The leak was reproduced using the following script:
```
ab -H "Authorization:Bearer eyJ0e...Mtzvo" \
-H "x-jira-Authorization:Basic cndvcnNub3A6Tm8sIHRoaXMgaXMgbm90IG15IHBhc3N3b3JkIQ==" \
-H "x-jira-base-url:https://jira-euc.eng.vmware.com/jira/" \
-H "x-routing-prefix:foo" \
-T application/json \
-p body.json \
-c 10 -n 10000 localhost:8060/cards/requests
```