### PR TITLE
APF-1247 Fix container memory settings

### DIFF
--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -85,7 +85,7 @@
                                                 <arg>-server</arg>
                                                 <arg>-XX:+UnlockExperimentalVMOptions</arg>
                                                 <arg>-XX:+UseCGroupMemoryLimitForHeap</arg>
-                                                <arg>-XX:MaxRAMFraction=1</arg>
+                                                <arg>-XX:MaxRAMFraction=2</arg>
                                                 <arg>-XX:+HeapDumpOnOutOfMemoryError</arg>
                                                 <arg>-XX:HeapDumpPath=/tmp</arg>
                                                 <arg>-jar</arg>


### PR DESCRIPTION
Switched the RAM fraction to 2. Confusingly, this means 1/2.
The problem was that 1 really does mean 100%, not some number that
allows headroom for non-heap memory.
The cause of the problem was having too much faith in this blog:
https://blog.csanchez.org/2017/05/31/running-a-jvm-in-a-container-without-getting-killed
The author "proves" that there is headroom by using -XshowSettings:vm and looking
at Max. Heap Size. He (and I) should have used -XX:+PrintFlagsFinal, which shows
MaxHeapSize equalling the hard limit of the container.
Java 10 improves things by adding -XX:MaxRAMPercentage:
http://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html