### PR TITLE
APF-1403: Downgrade jjwt to 0.9.1

### DIFF
--- a/common/connectors-test/pom.xml
+++ b/common/connectors-test/pom.xml
@@ -43,15 +43,7 @@
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
+            <artifactId>jjwt</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/common/core-test/pom.xml
+++ b/common/core-test/pom.xml
@@ -37,18 +37,6 @@
             <artifactId>spring-hateoas</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,20 +80,8 @@
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt-api</artifactId>
-                <version>0.10.1</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt-impl</artifactId>
-                <version>0.10.1</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt-jackson</artifactId>
-                <version>0.10.1</version>
-                <scope>runtime</scope>
+                <artifactId>jjwt</artifactId>
+                <version>0.9.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
* Downgrades jjwt from 0.10.1 to 0.9.1 until vIDM key strength is increased

Signed-off-by: John Bard <jbard@vmware.com>