### PR TITLE
Apf 1394 make concur fail safe for invalid report ids

### DIFF
--- a/connectors/concur/src/main/java/com/vmware/connectors/concur/ConcurController.java
+++ b/connectors/concur/src/main/java/com/vmware/connectors/concur/ConcurController.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -199,7 +200,7 @@ public class ConcurController {
 
         return fetchOAuthToken(authHeader, clientId, clientSecret)
                 .flatMap(oauthHeader -> getReportDetails(oauthHeader, id, baseUrl))
-                .onErrorResume(Reactive::skipOnNotFound)
+                .onErrorResume(throwable -> Reactive.skipOnStatus(throwable, HttpStatus.BAD_REQUEST))
                 .map(entity -> convertResponseIntoCard(entity,
                         id,
                         routingPrefix,

--- a/connectors/concur/src/test/java/com/vmware/connectors/concur/ConcurControllerTest.java
+++ b/connectors/concur/src/test/java/com/vmware/connectors/concur/ConcurControllerTest.java
@@ -53,6 +53,7 @@ class ConcurControllerTest extends ControllerTestsBase {
 
     private static final String REPORT_ID_1 = "79D89435DAE94F53BF60";
     private static final String REPORT_ID_2 = "F49BD54084CE4C09BD65";
+    private static final String INVALID_REPORT_ID = "invalid-report-id";
 
     @Value("classpath:concur/responses/approved.xml")
     private Resource approved;
@@ -150,6 +151,22 @@ class ConcurControllerTest extends ControllerTestsBase {
                 .andRespond(withSuccess(oauthToken, APPLICATION_JSON));
 
         testRequestCards("request.json", resFile, lang);
+    }
+
+    @Test
+    void testRequestCardsWithInvalidReportId() throws Exception {
+        expect(REPORT_ID_1).andRespond(withSuccess(
+                fromFile("/concur/responses/report_id_1.json")
+                        .replace("${concur_host}", mockBackend.url("")), APPLICATION_JSON));
+
+        expect(INVALID_REPORT_ID).andRespond(withStatus(HttpStatus.BAD_REQUEST));
+
+        mockConcurServer.expect(ExpectedCount.manyTimes(), requestTo("/oauth2/v0/token"))
+                .andExpect(method(POST))
+                .andExpect(MockRestRequestMatchers.content().contentTypeCompatibleWith(APPLICATION_FORM_URLENCODED))
+                .andRespond(withSuccess(oauthToken, APPLICATION_JSON));
+
+        testRequestCards("request_with_invalid_report_id.json", "single_card_response.json", StringUtils.EMPTY);
     }
 
     @Test

--- a/connectors/concur/src/test/resources/concur/requests/request_with_invalid_report_id.json
+++ b/connectors/concur/src/test/resources/concur/requests/request_with_invalid_report_id.json
@@ -1,0 +1,5 @@
+{
+  "tokens": {
+    "expense_report_id": ["79D89435DAE94F53BF60", "invalid-report-id"]
+  }
+}

--- a/connectors/concur/src/test/resources/connector/responses/single_card_response.json
+++ b/connectors/concur/src/test/resources/connector/responses/single_card_response.json
@@ -1,0 +1,87 @@
+{
+  "objects": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "name": "Concur",
+      "creation_date": "1970-01-01T00:00:00Z",
+      "template": {
+        "href": "https://hero/connectors/concur/templates/generic.hbs"
+      },
+      "header": {
+        "title": "[Concur] Expense Report Pending Your Approval",
+        "subtitle": []
+      },
+      "body": {
+        "description": "Test Concur connector-1",
+        "fields": [
+          {
+            "type": "GENERAL",
+            "title": "Approval status",
+            "description": "Submitted & Pending Approval"
+          },
+          {
+            "type": "GENERAL",
+            "title": "Report From",
+            "description": "Ajmera, Rahul"
+          },
+          {
+            "type": "GENERAL",
+            "title": "Report Purpose",
+            "description": "Concur"
+          },
+          {
+            "type": "GENERAL",
+            "title": "Report Amount",
+            "description": "10000.00 INR"
+          }
+        ]
+      },
+      "actions": [
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "primary": true,
+          "label": "Approve",
+          "url": {
+            "href": "https://hero/connectors/concur/api/expense/approve/79D89435DAE94F53BF60"
+          },
+          "type": "POST",
+          "action_key": "USER_INPUT",
+          "request": {},
+          "user_input": [
+            {
+              "id": "reason",
+              "label": "Reason for approval",
+              "min_length": 1
+            }
+          ],
+          "completed_label": "Approved",
+          "allow_repeated": false,
+          "mutually_exclusive_set_id": "approval-actions"
+        },
+        {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "label": "Reject",
+          "url": {
+            "href": "https://hero/connectors/concur/api/expense/reject/79D89435DAE94F53BF60"
+          },
+          "type": "POST",
+          "action_key": "USER_INPUT",
+          "request": {},
+          "user_input": [
+            {
+              "id": "reason",
+              "label": "Reason for rejection",
+              "min_length": 1
+            }
+          ],
+          "completed_label": "Rejected",
+          "allow_repeated": false,
+          "mutually_exclusive_set_id": "approval-actions"
+        }
+      ],
+      "image": {
+        "href": "https://my-connector/images/connector.png"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Tested the changes with a valid and invalid report id. I was able to get the card result for the valid report.