### PR TITLE
APF-1357 Snapshot version updated to 2.3

### DIFF
--- a/common/connectors-config/pom.xml
+++ b/common/connectors-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>common</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/connectors-test/pom.xml
+++ b/common/connectors-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>common</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/core-test/pom.xml
+++ b/common/core-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>common</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/core/pom.xml
+++ b/common/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>common</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/connectors/airwatch/pom.xml
+++ b/connectors/airwatch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>airwatch-connector</artifactId>

--- a/connectors/aws-cert/pom.xml
+++ b/connectors/aws-cert/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/connectors/bitbucket-server/pom.xml
+++ b/connectors/bitbucket-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/connectors/concur/pom.xml
+++ b/connectors/concur/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connectors/github-pr/pom.xml
+++ b/connectors/github-pr/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/connectors/gitlab-pr/pom.xml
+++ b/connectors/gitlab-pr/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/connectors/jira/pom.xml
+++ b/connectors/jira/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/connectors/salesforce/pom.xml
+++ b/connectors/salesforce/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connectors/servicenow/pom.xml
+++ b/connectors/servicenow/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vmware.card-connectors</groupId>
         <artifactId>connectors</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vmware.card-connectors</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
 


### PR DESCRIPTION
Since we switched to multi-object type, I thought we can make it 2.3 Snapshot.
Then it'll be easy to use for snapshots in other repos. (Like SFDC internal)