### PR TITLE
APF-2100: Schema URL fix for Card object type schema doc href

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The connectors are written in Java and use the [Spring Framework](https://spring
 [Spring Boot](https://projects.spring.io/spring-boot/), embedding [Tomcat](http://tomcat.apache.org/) 8.5.
 
 For a detailed, language-neutral, specification for how to develop connectors, please see the
-[Card Connectors Guide](https://github.com/vmwaresamples/card-connectors-guide).
+[Card Connectors Guide](https://github.com/vmware-samples/card-connectors-guide).
 
 This repository also includes common libraries. Please see their [README](https://github.com/vmware/connectors-workspace-one/blob/master/common/README.md) for more details.
 

--- a/connectors/airwatch/src/main/resources/static/discovery/metadata.json
+++ b/connectors/airwatch/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "udid": {

--- a/connectors/airwatch/src/test/resources/connector/responses/metadata.json
+++ b/connectors/airwatch/src/test/resources/connector/responses/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "udid": {

--- a/connectors/aws-cert/src/main/resources/static/discovery/metadata.json
+++ b/connectors/aws-cert/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "approval_urls": {

--- a/connectors/aws-cert/src/test/resources/discovery/metadata.json
+++ b/connectors/aws-cert/src/test/resources/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "approval_urls": {

--- a/connectors/bitbucket-server/src/main/resources/static/discovery/metadata.json
+++ b/connectors/bitbucket-server/src/main/resources/static/discovery/metadata.json
@@ -8,7 +8,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "projects_pr_email_subject": {

--- a/connectors/concur/src/main/resources/static/discovery/metadata.json
+++ b/connectors/concur/src/main/resources/static/discovery/metadata.json
@@ -8,7 +8,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "concur_automated_email_subject": {

--- a/connectors/github-pr/src/main/resources/static/discovery/metadata.json
+++ b/connectors/github-pr/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "pull_request_urls": {

--- a/connectors/gitlab-pr/src/main/resources/static/discovery/metadata.json
+++ b/connectors/gitlab-pr/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "merge_request_urls": {

--- a/connectors/hub-concur/src/main/resources/static/discovery/metadata.json
+++ b/connectors/hub-concur/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "_temporary": {

--- a/connectors/hub-coupa/src/main/resources/static/discovery/metadata.json
+++ b/connectors/hub-coupa/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
     "object_types": {
         "card": {
             "doc": {
-                "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+                "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
             },
             "fields": {
                 "_temporary": {

--- a/connectors/hub-salesforce/src/main/resources/static/discovery/metadata.json
+++ b/connectors/hub-salesforce/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "_temporary": {

--- a/connectors/hub-servicenow/src/main/resources/static/discovery/metadata.json
+++ b/connectors/hub-servicenow/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "_temporary": {

--- a/connectors/jira/src/main/resources/static/discovery/metadata.json
+++ b/connectors/jira/src/main/resources/static/discovery/metadata.json
@@ -8,7 +8,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "issue_id": {

--- a/connectors/salesforce/src/main/resources/static/discovery/metadata.json
+++ b/connectors/salesforce/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "user_email": {

--- a/connectors/servicenow/src/main/resources/static/discovery/metadata.json
+++ b/connectors/servicenow/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "ticket_id": {

--- a/connectors/testdrive-salesforce/src/main/resources/static/discovery/metadata.json
+++ b/connectors/testdrive-salesforce/src/main/resources/static/discovery/metadata.json
@@ -5,7 +5,7 @@
   "object_types": {
     "card": {
       "doc": {
-        "href": "https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses"
+        "href": "https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses"
       },
       "fields": {
         "user_email": {


### PR DESCRIPTION
The schema URL for the Card Responses object has moved from:

https://github.com/vmwaresamples/card-connectors-guide/wiki/Card-Responses

to:

https://github.com/vmware-samples/card-connectors-guide/wiki/Card-Responses

This PR changes the discovery to reflect this new URL.